### PR TITLE
Philip/processing speed ups

### DIFF
--- a/python_code/batch_processing/batch_pipeline.py
+++ b/python_code/batch_processing/batch_pipeline.py
@@ -32,6 +32,14 @@ def batch_full_pipeline(
     """
     batch_timings: dict[Path, float] = {}
     for recording_folder_path, calibration_toml_path in recordings:
+        # Required setup for new sessions (not yet synchronized)
+        if "clips" not in str(recording_folder_path) and "full_recording" not in str(recording_folder_path):
+            recording_folder_path = recording_folder_path / "full_recording"
+        recording_folder_path.mkdir(exist_ok=True, parents=False)
+        (recording_folder_path / "mocap_data").mkdir(exist_ok=True, parents=False)
+        (recording_folder_path / "eye_data").mkdir(exist_ok=True, parents=False)
+
+        print(f"Processing {recording_folder_path}")
         print(f"\n{'=' * 60}")
         print(f"Processing: {recording_folder_path}")
         t0 = time.perf_counter()
@@ -58,11 +66,14 @@ def batch_full_pipeline(
 
 
 if __name__ == "__main__":
-    recordings = [
+    recordings: list[tuple[Path, Path | None]] = [
         # (recording_folder_path, calibration_toml_path or None)
-        (Path("/home/scholl-lab/ferret_recordings/session_2025-10-22_ferret_420_EO13/full_recording"), None),
-        (Path("/home/scholl-lab/ferret_recordings/session_2025-10-22_ferret_420_EO14/full_recording"), None),
+        (Path("/home/scholl-lab/ferret_recordings/session_2026-03-16_ferret_411_P49_E8"), None),
+        (Path("/home/scholl-lab/ferret_recordings/session_2026-03-10_ferret_411_P43_E2"), None),
+        (Path("/home/scholl-lab/ferret_recordings/session_2026-03-02_ferret_405_EO2"), None),
+        (Path("/home/scholl-lab/ferret_recordings/session_2026-03-09_ferret_407_EO9"), None),
     ]
+
 
     batch_full_pipeline(
         recordings=recordings,

--- a/python_code/batch_processing/batch_pipeline.py
+++ b/python_code/batch_processing/batch_pipeline.py
@@ -1,0 +1,76 @@
+"""
+Run full_pipeline on multiple recordings in sequence.
+
+Each recording can specify its own calibration toml path, or None to let
+the pipeline locate it automatically.
+"""
+from pathlib import Path
+import time
+
+from python_code.batch_processing.full_pipeline import full_pipeline
+
+
+def batch_full_pipeline(
+    recordings: list[tuple[Path, Path | None]],
+    include_eye: bool = True,
+    overwrite_synchronization: bool = False,
+    overwrite_calibration: bool = False,
+    overwrite_dlc: bool = False,
+    overwrite_triangulation: bool = False,
+    overwrite_eye_postprocessing: bool = False,
+    overwrite_skull_postprocessing: bool = False,
+    overwrite_gaze: bool = False,
+):
+    """
+    Run full_pipeline on a list of recordings sequentially.
+
+    Args:
+        recordings: List of (recording_folder_path, calibration_toml_path) pairs.
+            Pass None as the calibration path to let the pipeline find it automatically.
+        include_eye: Whether to include eye processing.
+        overwrite_*: Overwrite flags forwarded to full_pipeline for every recording.
+    """
+    batch_timings: dict[Path, float] = {}
+    for recording_folder_path, calibration_toml_path in recordings:
+        print(f"\n{'=' * 60}")
+        print(f"Processing: {recording_folder_path}")
+        t0 = time.perf_counter()
+        full_pipeline(
+            recording_folder_path=recording_folder_path,
+            calibration_toml_path=calibration_toml_path,
+            include_eye=include_eye,
+            overwrite_synchronization=overwrite_synchronization,
+            overwrite_calibration=overwrite_calibration,
+            overwrite_dlc=overwrite_dlc,
+            overwrite_triangulation=overwrite_triangulation,
+            overwrite_eye_postprocessing=overwrite_eye_postprocessing,
+            overwrite_skull_postprocessing=overwrite_skull_postprocessing,
+            overwrite_gaze=overwrite_gaze,
+        )
+        batch_timings[recording_folder_path] = time.perf_counter() - t0
+
+    print(f"\n{'=' * 60}")
+    print("=== Batch Summary ===")
+    for path, elapsed in batch_timings.items():
+        print(f"  {path.name}: {elapsed:.1f}s")
+    print("  ---")
+    print(f"  Total: {sum(batch_timings.values()):.1f}s")
+
+
+if __name__ == "__main__":
+    recordings = [
+        # (recording_folder_path, calibration_toml_path or None)
+        (Path("/home/scholl-lab/ferret_recordings/session_2025-10-22_ferret_420_EO13/full_recording"), None),
+        (Path("/home/scholl-lab/ferret_recordings/session_2025-10-22_ferret_420_EO14/full_recording"), None),
+    ]
+
+    batch_full_pipeline(
+        recordings=recordings,
+        overwrite_synchronization=False,
+        overwrite_calibration=False,
+        overwrite_dlc=False,
+        overwrite_triangulation=False,
+        overwrite_eye_postprocessing=False,
+        overwrite_skull_postprocessing=False,
+        overwrite_gaze=False,
+    )

--- a/python_code/batch_processing/check_progress/check_progress.py
+++ b/python_code/batch_processing/check_progress/check_progress.py
@@ -79,7 +79,7 @@ def check_progress(ferret_recordings_path: Path) -> pd.DataFrame:
     
 
 if __name__ == "__main__":
-    ferret_recordings_path = Path("/Users/philipqueen/Documents/GitHub/bs/ferret_recordings")
+    ferret_recordings_path = Path("/home/scholl-lab/ferret_recordings")
     # check if recording_progress.csv exists, if it does, load it and update it, if it doesn't, create it
     df = check_progress(ferret_recordings_path)
     print(df)

--- a/python_code/batch_processing/full_pipeline.py
+++ b/python_code/batch_processing/full_pipeline.py
@@ -105,7 +105,10 @@ def run_skellyclicker_subprocess(
         recording_folder_path: Path,
         venv_path: str = "/home/scholl-lab/anaconda3/envs/skellyclicker/bin/python",
         script_path: str = "/home/scholl-lab/skellyclicker/skellyclicker/scripts/process_recording.py",
-        include_eye: bool = True,):
+        include_eye: bool = True,
+        include_body: bool = True,
+        include_toy: bool = True
+    ):
     clean_env = os.environ.copy()
     clean_env.pop("PYTHONPATH", None)
     clean_env.pop("PYTHONHOME", None)
@@ -114,6 +117,10 @@ def run_skellyclicker_subprocess(
     command_list = [venv_path, "-u", script_path, recording_folder_path]
     if not include_eye:
         command_list.append("--skip-eye")
+    if not include_body:
+        command_list.append("--skip-body")
+    if not include_toy:
+        command_list.append("--skip-toy")
 
     _run_subprocess_streaming(command_list, clean_env, use_pty=True)
 
@@ -176,29 +183,9 @@ def full_pipeline(
     recording_folder = RecordingFolder.from_folder_path(folder=recording_folder_path)
     timings: dict[str, float | None] = {}
 
-    # Force DLC reprocessing if any output was generated with an outdated model iteration
-    if not overwrite_dlc and (
-        _dlc_metadata_is_outdated(recording_folder.head_body_dlc_output, HEAD_DLC_ITERATION)
-        or _dlc_metadata_is_outdated(recording_folder.eye_dlc_output, EYE_DLC_ITERATION)
-        or _dlc_metadata_is_outdated(recording_folder.toy_dlc_output, TOY_DLC_ITERATION)
-    ):
-        print("DLC outputs are from an outdated model iteration, forcing DLC reprocessing")
-        overwrite_dlc = True
-
     # Propagate overwrite flags through dependent steps
     if overwrite_synchronization:
         overwrite_calibration = True
-
-    if overwrite_dlc:
-        overwrite_eye_postprocessing = True
-        if overwrite_calibration:
-            overwrite_triangulation = True
-
-    if overwrite_triangulation:
-        overwrite_skull_postprocessing = True
-
-    if overwrite_eye_postprocessing or overwrite_skull_postprocessing:
-        overwrite_gaze = True
 
     # Synchronization
     if overwrite_synchronization or not recording_folder.is_synchronized():
@@ -224,17 +211,45 @@ def full_pipeline(
 
     recording_folder.check_calibration()
 
-    # DLC
-    if overwrite_dlc or not recording_folder.is_dlc_processed():
+    # DLC — check each model independently
+    run_dlc_body = overwrite_dlc or _dlc_metadata_is_outdated(recording_folder.head_body_dlc_output, HEAD_DLC_ITERATION)
+    run_dlc_eye = include_eye and (overwrite_dlc or _dlc_metadata_is_outdated(recording_folder.eye_dlc_output, EYE_DLC_ITERATION))
+    run_dlc_toy = overwrite_dlc or _dlc_metadata_is_outdated(recording_folder.toy_dlc_output, TOY_DLC_ITERATION)
+
+    if not overwrite_dlc:
+        if run_dlc_body:
+            print("Body DLC outputs are from an outdated model iteration, forcing body DLC reprocessing")
+        if run_dlc_eye:
+            print("Eye DLC outputs are from an outdated model iteration, forcing eye DLC reprocessing")
+        if run_dlc_toy:
+            print("Toy DLC outputs are from an outdated model iteration, forcing toy DLC reprocessing")
+
+    if run_dlc_body or run_dlc_eye or run_dlc_toy:
         print("Running pose estimation...")
         t0 = time.perf_counter()
-        run_skellyclicker_subprocess(recording_folder_path=recording_folder_path)
+        run_skellyclicker_subprocess(
+            recording_folder_path=recording_folder_path,
+            include_body=run_dlc_body,
+            include_eye=run_dlc_eye,
+            include_toy=run_dlc_toy,
+        )
         timings["Pose estimation"] = time.perf_counter() - t0
         print(f"Pose estimation complete ({timings['Pose estimation']:.1f}s)")
     else:
         timings["Pose estimation"] = None
+        print("Pose estimation: skipped")
 
     recording_folder.check_dlc_output()
+
+    # Propagate DLC results to downstream steps
+    if run_dlc_eye:
+        overwrite_eye_postprocessing = True
+    if run_dlc_body and overwrite_calibration:
+        overwrite_triangulation = True
+    if overwrite_triangulation:
+        overwrite_skull_postprocessing = True
+    if overwrite_eye_postprocessing or overwrite_skull_postprocessing:
+        overwrite_gaze = True
 
     # Triangulation
     if overwrite_triangulation or not recording_folder.is_triangulated():

--- a/python_code/batch_processing/full_pipeline.py
+++ b/python_code/batch_processing/full_pipeline.py
@@ -12,6 +12,7 @@ import json
 import subprocess
 import os
 import sys
+import time
 
 from python_code.batch_processing.postprocess_recording import process_recording
 from python_code.cameras.postprocess import postprocess
@@ -133,7 +134,7 @@ def run_triangulation_subprocess(
     if skip_toy:
         command_list.append("--skip-toy")
 
-    _run_subprocess_streaming(command_list, clean_env)
+    _run_subprocess_streaming(command_list, clean_env, use_pty=True)
 
 
 def run_calibration_subprocess(
@@ -156,7 +157,7 @@ def run_calibration_subprocess(
         "--use-groundplane"
     ]
 
-    _run_subprocess_streaming(command_list, clean_env)
+    _run_subprocess_streaming(command_list, clean_env, use_pty=True)
 
 
 
@@ -173,6 +174,7 @@ def full_pipeline(
     overwrite_gaze: bool = False
 ):
     recording_folder = RecordingFolder.from_folder_path(folder=recording_folder_path)
+    timings: dict[str, float | None] = {}
 
     # Force DLC reprocessing if any output was generated with an outdated model iteration
     if not overwrite_dlc and (
@@ -201,23 +203,38 @@ def full_pipeline(
     # Synchronization
     if overwrite_synchronization or not recording_folder.is_synchronized():
         print(f"Synchronizing videos at {recording_folder.base_recordings_folder}")
+        t0 = time.perf_counter()
         postprocess(session_folder_path=recording_folder.base_recordings_folder, include_eyes=include_eye)
+        timings["Synchronization"] = time.perf_counter() - t0
+        print(f"Synchronization complete ({timings['Synchronization']:.1f}s)")
+    else:
+        timings["Synchronization"] = None
+
     recording_folder.check_synchronization()
-    print("Synchronizing videos completed")
 
     # Calibration
     if overwrite_calibration or not recording_folder.is_calibrated():
         print("Calibrating session...")
+        t0 = time.perf_counter()
         run_calibration_subprocess(calibration_videos_path=recording_folder.calibration_videos)
+        timings["Calibration"] = time.perf_counter() - t0
+        print(f"Calibration complete ({timings['Calibration']:.1f}s)")
+    else:
+        timings["Calibration"] = None
+
     recording_folder.check_calibration()
-    print("Calibration complete")
 
     # DLC
     if overwrite_dlc or not recording_folder.is_dlc_processed():
         print("Running pose estimation...")
+        t0 = time.perf_counter()
         run_skellyclicker_subprocess(recording_folder_path=recording_folder_path)
+        timings["Pose estimation"] = time.perf_counter() - t0
+        print(f"Pose estimation complete ({timings['Pose estimation']:.1f}s)")
+    else:
+        timings["Pose estimation"] = None
+
     recording_folder.check_dlc_output()
-    print("Pose estimation complete")
 
     # Triangulation
     if overwrite_triangulation or not recording_folder.is_triangulated():
@@ -226,31 +243,51 @@ def full_pipeline(
         if calibration_toml_path is None:
             raise ValueError("No calibration toml file found, could not run triangulation")
         print("Running triangulation...")
+        t0 = time.perf_counter()
         run_triangulation_subprocess(recording_folder_path=recording_folder_path, calibration_toml_path=calibration_toml_path)
+        timings["Triangulation"] = time.perf_counter() - t0
+        print(f"Triangulation complete ({timings['Triangulation']:.1f}s)")
+    else:
+        timings["Triangulation"] = None
+
     recording_folder.check_triangulation()
-    print("Triangulation complete")
 
     eye_postprocessing = recording_folder.is_eye_postprocessed()
     skull_postprocessing = recording_folder.is_skull_postprocessed()
     gaze_postprocessing = recording_folder.is_gaze_postprocessed()
-    
 
     run_eye_postprocessing = include_eye and (overwrite_eye_postprocessing or not eye_postprocessing)
     run_skull_postprocessing = overwrite_skull_postprocessing or not skull_postprocessing
     run_gaze_postprocessing = include_eye and (overwrite_gaze or not gaze_postprocessing)
-    if run_eye_postprocessing or run_skull_postprocessing or run_gaze_postprocessing: 
+    if run_eye_postprocessing or run_skull_postprocessing or run_gaze_postprocessing:
         print("Running gaze processing...")
+        t0 = time.perf_counter()
         process_recording(
             recording_folder=recording_folder,
             skip_eye=not run_eye_postprocessing,
             skip_skull=not run_skull_postprocessing,
             skip_gaze=not run_gaze_postprocessing
         )
+        timings["Gaze processing"] = time.perf_counter() - t0
+        print(f"Gaze processing complete ({timings['Gaze processing']:.1f}s)")
+    else:
+        timings["Gaze processing"] = None
+
     recording_folder.check_eye_postprocessing()
     recording_folder.check_skull_postprocessing()
     recording_folder.check_gaze_postprocessing()
-    print("Gaze calculations complete")
-    print(f"Session processed: {recording_folder_path}")
+
+    print(f"\nSession processed: {recording_folder_path}")
+    print("\n=== Pipeline Timing Summary ===")
+    total = 0.0
+    for step, elapsed in timings.items():
+        if elapsed is None:
+            print(f"  {step}: skipped")
+        else:
+            print(f"  {step}: {elapsed:.1f}s")
+            total += elapsed
+    print(f"  ---")
+    print(f"  Total: {total:.1f}s")
 
 
 if __name__=="__main__":

--- a/python_code/batch_processing/full_pipeline.py
+++ b/python_code/batch_processing/full_pipeline.py
@@ -292,7 +292,7 @@ def full_pipeline(
 
 if __name__=="__main__":
     recording_folder_path = Path(
-        "/home/scholl-lab/ferret_recordings/session_2025-10-22_ferret_420_EO13/full_recording"
+        "/home/scholl-lab/ferret_recordings/session_2026-03-12_ferret_403_P45_E3"
     )
 
     if "clips" not in str(recording_folder_path) and "full_recording" not in str(recording_folder_path):

--- a/python_code/batch_processing/postprocess_recording.py
+++ b/python_code/batch_processing/postprocess_recording.py
@@ -19,7 +19,7 @@ def process_recording(
         # process eye data
         process_eye_session_from_recording_folder(recording_folder=recording_folder.folder_path)
 
-        # # run eye confidence analysis
+        # run eye confidence analysis
         bad_eye_data(recording_folder=recording_folder.folder_path)
 
     if not skip_skull:

--- a/python_code/batch_processing/postprocess_recording.py
+++ b/python_code/batch_processing/postprocess_recording.py
@@ -20,7 +20,7 @@ def process_recording(
         process_eye_session_from_recording_folder(recording_folder=recording_folder.folder_path)
 
         # run eye confidence analysis
-        bad_eye_data(recording_folder=recording_folder.folder_path)
+        bad_eye_data(recording_folder=recording_folder)
 
     if not skip_skull:
         # process ceres solver

--- a/python_code/cameras/synchronization/timestamp_synchronize.py
+++ b/python_code/cameras/synchronization/timestamp_synchronize.py
@@ -63,7 +63,7 @@ class TimestampSynchronize:
         self.correct_intrinsics = correct_intrinsics
         if not isinstance(folder_path, Path):
             folder_path = Path(folder_path)
-        if not folder_path.exists:
+        if not folder_path.exists():
             raise FileNotFoundError("Input folder path does not exist")
 
         raw_videos_path = folder_path / "raw_videos"
@@ -94,7 +94,6 @@ class TimestampSynchronize:
         with self.index_to_serial_number_map_path.open() as fp:
             self.index_to_serial_number_map = json.load(fp)
 
-
         self.synched_videos_path.mkdir(parents=True, exist_ok=True)
 
     def synchronize(self):
@@ -124,7 +123,6 @@ class TimestampSynchronize:
 
         # Release main-process handles before workers open the same files
         self.release_captures()
-        self.release_writers()
 
         num_workers = min(len(sync_args_list), multiprocessing.cpu_count())
         print(f"Synchronizing {len(sync_args_list)} videos with {num_workers} workers")
@@ -148,7 +146,6 @@ class TimestampSynchronize:
         if self.correct_intrinsics:
             self.create_intrinsics_correctors()
         self.print_diagnostics()
-        self.create_writer_dict()
         self.create_starting_timestamp_dict()
         self.create_frame_offset_dict()
 
@@ -181,21 +178,6 @@ class TimestampSynchronize:
 
         if len(self.intrinsics_correctors) != len(self.capture_dict):
             raise ValueError("Unable to find intrinsics for all videos")
-
-    def create_writer_dict(self):
-        file_suffix = "_synchronized_corrected" if self.correct_intrinsics else "_synchronized"
-        self.writer_dict = {
-            video_name: cv2.VideoWriter(
-                str(self.synched_videos_path / (video_name.split(".")[0] + file_suffix + ".mp4")),
-                cv2.VideoWriter.fourcc(*"mp4v"),
-                cap.get(cv2.CAP_PROP_FPS),
-                (
-                    int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)),
-                    int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)),
-                ),
-            )
-            for video_name, cap in self.capture_dict.items()
-        }
 
     def create_starting_timestamp_dict(self):
         self.starting_timestamp_dict = {
@@ -243,7 +225,7 @@ class TimestampSynchronize:
             earliest_camera = next(key for key, value in start_times.items() if value == min(start_times.values()))
 
             # move latest back
-            if latest_camera != reference_camera:
+            if latest_camera != reference_camera and best_frame_offsets[latest_camera] > 0:
                 trial_frame_offsets = best_frame_offsets.copy()
                 trial_frame_offsets[latest_camera] -= 1
                 trial_start_times = self._get_start_times_from_frame_offsets(trial_frame_offsets)
@@ -252,6 +234,7 @@ class TimestampSynchronize:
                 if trial_spread < best_spread:
                     best_spread = trial_spread
                     best_frame_offsets = trial_frame_offsets
+                    start_times = trial_start_times
                     should_continue = True
                     continue
 
@@ -265,11 +248,12 @@ class TimestampSynchronize:
                 if trial_spread < best_spread:
                     best_spread = trial_spread
                     best_frame_offsets = trial_frame_offsets
+                    start_times = trial_start_times
                     should_continue = True
                     continue
 
             # move earliest forward and latest back
-            if earliest_camera != reference_camera and latest_camera != reference_camera:
+            if earliest_camera != reference_camera and latest_camera != reference_camera and best_frame_offsets[latest_camera] > 0:
                 trial_frame_offsets = best_frame_offsets.copy()
                 trial_frame_offsets[latest_camera] -= 1
                 trial_frame_offsets[earliest_camera] += 1
@@ -279,6 +263,7 @@ class TimestampSynchronize:
                 if trial_spread < best_spread:
                     best_spread = trial_spread
                     best_frame_offsets = trial_frame_offsets
+                    start_times = trial_start_times
                     should_continue = True
                     continue
 
@@ -323,17 +308,12 @@ class TimestampSynchronize:
     def close(self):
         print("Closing all capture objects and writers")
         self.release_captures()
-        self.release_writers()
 
     def release_captures(self):
         for cap in self.capture_dict.values():
             cap.release()
         self.capture_dict = {}
 
-    def release_writers(self):
-        for writer in self.writer_dict.values():
-            writer.release()
-        self.writer_dict = {}
 
 
 if __name__ == "__main__":

--- a/python_code/cameras/synchronization/timestamp_synchronize.py
+++ b/python_code/cameras/synchronization/timestamp_synchronize.py
@@ -1,4 +1,6 @@
+import multiprocessing
 import shutil
+from dataclasses import dataclass
 from typing import Dict
 import cv2
 import numpy as np
@@ -7,6 +9,53 @@ import json
 from pathlib import Path
 from python_code.cameras.diagnostics.skellycam_plots import timestamps_array_to_dictionary, calculate_camera_diagnostic_results
 from python_code.cameras.intrinsics.intrinsics_corrector import IntrinsicsCorrector, get_calibrations_from_json
+
+
+@dataclass
+class VideoSyncArgs:
+    video_name: str
+    input_path: Path
+    output_path: Path
+    fps: float
+    width: int
+    height: int
+    offset: int
+    target_framecount: int
+    flip_videos: bool
+    correct_intrinsics: bool
+    intrinsics_corrector: IntrinsicsCorrector | None  # None when correct_intrinsics=False
+
+
+def _synchronize_single_video(args: VideoSyncArgs) -> str:
+    cap = cv2.VideoCapture(str(args.input_path))
+    writer = cv2.VideoWriter(
+        str(args.output_path),
+        cv2.VideoWriter.fourcc(*"mp4v"),
+        args.fps,
+        (args.width, args.height),
+    )
+    current_framecount = 0
+    offset = args.offset
+    try:
+        while current_framecount < args.target_framecount:
+            ret, frame = cap.read()
+            if not ret:
+                raise ValueError(f"{args.video_name} has no more frames.")
+            if offset <= 0:
+                if args.flip_videos:
+                    frame = cv2.flip(frame, -1)
+                if args.correct_intrinsics:
+                    frame = args.intrinsics_corrector.correct_frame(frame)
+                writer.write(frame)
+                current_framecount += 1
+            else:
+                offset -= 1
+    finally:
+        cap.release()
+        writer.release()
+    print(f"Finished synchronizing: {args.video_name}")
+    return args.video_name
+
 
 class TimestampSynchronize:
     def __init__(self, folder_path: Path, flip_videos: bool = False, correct_intrinsics: bool = True):
@@ -54,23 +103,34 @@ class TimestampSynchronize:
             self.get_lowest_postoffset_frame_count() - 1
         )  # -1 accounts for rounding errors in offset i.e. drop a frame off the end to be sure we don't overflow array
         print(f"synchronizing videos to target framecount: {target_framecount}")
+
+        file_suffix = "_synchronized_corrected" if self.correct_intrinsics else "_synchronized"
+        sync_args_list = []
         for video_name, cap in self.capture_dict.items():
-            print(f"synchronizing: {video_name}")
-            current_framecount = 0
-            offset = self.frame_offset_dict[video_name.split(".")[0]]
-            while current_framecount < target_framecount:  # < to account for 0 indexing
-                ret, frame = cap.read()
-                if not ret:
-                    raise ValueError(f"{video_name} has no more frames.")
-                if offset <= 0:
-                    if self.flip_videos:
-                        frame = cv2.flip(frame, -1)
-                    if self.correct_intrinsics:
-                        frame = self.intrinsics_correctors[video_name].correct_frame(frame)
-                    self.writer_dict[video_name].write(frame)
-                    current_framecount += 1
-                else:
-                    offset -= 1
+            serial = video_name.split(".")[0]
+            sync_args_list.append(VideoSyncArgs(
+                video_name=video_name,
+                input_path=self.raw_videos_path / video_name,
+                output_path=self.synched_videos_path / (serial + file_suffix + ".mp4"),
+                fps=self.fps,
+                width=int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)),
+                height=int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)),
+                offset=self.frame_offset_dict[serial],
+                target_framecount=target_framecount,
+                flip_videos=self.flip_videos,
+                correct_intrinsics=self.correct_intrinsics,
+                intrinsics_corrector=self.intrinsics_correctors.get(video_name) if self.correct_intrinsics else None,
+            ))
+
+        # Release main-process handles before workers open the same files
+        self.release_captures()
+        self.release_writers()
+
+        num_workers = min(len(sync_args_list), multiprocessing.cpu_count())
+        print(f"Synchronizing {len(sync_args_list)} videos with {num_workers} workers")
+        with multiprocessing.Pool(processes=num_workers) as pool:
+            pool.map(_synchronize_single_video, sync_args_list)
+
         print("Saving new timestamps files")
         self.save_new_timestamps(target_framecount=target_framecount)
         if self.timestamp_mapping_path.exists():
@@ -268,10 +328,12 @@ class TimestampSynchronize:
     def release_captures(self):
         for cap in self.capture_dict.values():
             cap.release()
+        self.capture_dict = {}
 
     def release_writers(self):
         for writer in self.writer_dict.values():
             writer.release()
+        self.writer_dict = {}
 
 
 if __name__ == "__main__":

--- a/python_code/eye_analysis/process_eye_session.py
+++ b/python_code/eye_analysis/process_eye_session.py
@@ -1,3 +1,4 @@
+import multiprocessing
 from pathlib import Path
 import pandas as pd
 
@@ -21,7 +22,6 @@ def process_eye_session(
     eye_1_timestamps_npy: Path,
     eye_0_video_path: Path,
     eye_1_video_path: Path,
-    head_data: Path | None = None
 ):
     recording_name = session_folder.stem
     output_data_folder = clip_folder / "eye_data" / "output_data"
@@ -47,20 +47,13 @@ def process_eye_session(
     merged_eye_output = merge_eye_output_csvs(eye_data_path=clip_folder / "eye_data")
     merged_eye_output.to_csv(clip_folder / "eye_data" / f"eye_data.csv", index=False)
     
-    # run video creation
-    create_stabilized_eye_videos(
-        base_path=clip_folder,
-        video_path=eye_0_video_path,
-        timestamps_npy_path=eye_0_timestamps_npy,
-        csv_path=eye_0_dlc_csv
-    )
-
-    create_stabilized_eye_videos(
-        base_path=clip_folder, 
-        video_path=eye_1_video_path,
-        timestamps_npy_path=eye_1_timestamps_npy,
-        csv_path=eye_1_dlc_csv
-    )
+    # run video creation for both eyes in parallel
+    video_args = [
+        (clip_folder, eye_0_video_path, eye_0_timestamps_npy, eye_0_dlc_csv),
+        (clip_folder, eye_1_video_path, eye_1_timestamps_npy, eye_1_dlc_csv),
+    ]
+    with multiprocessing.Pool(processes=2) as pool:
+        pool.starmap(create_stabilized_eye_videos, video_args)
 
 
 def process_eye_session_from_recording_folder(recording_folder: Path):

--- a/python_code/ferret_gaze/data_resampling/ferret_data_resampler.py
+++ b/python_code/ferret_gaze/data_resampling/ferret_data_resampler.py
@@ -9,6 +9,7 @@ All output files will have EXACTLY the same number of frames and identical times
 Videos are resampled to the 'display_videos' folder at the same level as the output directory.
 """
 import logging
+import multiprocessing
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -43,6 +44,36 @@ class VideoConfig:
     path: Path
     timestamps_path: Path
     name: str
+
+
+@dataclass
+class VideoResampleArgs:
+    """Arguments for a single video resampling worker."""
+
+    video_path: Path
+    timestamps_path: Path
+    common_timestamps_original: NDArray[np.float64]
+    output_path: Path
+    video_name: str
+    target_fps: float
+
+
+def _resample_video_worker(args: VideoResampleArgs) -> Path:
+    """Module-level worker for parallel video resampling."""
+    raw_video_timestamps = load_video_timestamps(args.timestamps_path)
+    video_timestamps = normalize_video_timestamps(
+        video_timestamps=raw_video_timestamps,
+        target_timestamps=args.common_timestamps_original,
+    )
+    resample_single_video(
+        video_path=args.video_path,
+        video_timestamps=video_timestamps,
+        target_timestamps=args.common_timestamps_original,
+        output_path=args.output_path,
+        video_name=args.video_name,
+        target_fps=args.target_fps,
+    )
+    return args.output_path
 
 
 def load_video_timestamps(timestamps_path: Path) -> NDArray[np.float64]:
@@ -494,12 +525,15 @@ def resample_videos(
 
     expected_frames = len(common_timestamps_original)
     output_dir.mkdir(parents=True, exist_ok=True)
-    output_paths: list[Path] = []
 
-    for config in video_configs:
+    # Separate skipped videos (already correct) from those needing resampling.
+    # Use index slots to preserve original ordering in the returned list.
+    output_results: list[Path | None] = [None] * len(video_configs)
+    worker_arg_list: list[tuple[int, VideoResampleArgs]] = []
+
+    for i, config in enumerate(video_configs):
         logger.info(f"\n--- Processing: {config.name} ---")
 
-        # Check if output already exists with correct frame count
         output_path = output_dir / f"{config.name}_resampled.mp4"
 
         if not recreate_videos and output_path.exists():
@@ -507,46 +541,34 @@ def resample_videos(
             if existing_frames == expected_frames:
                 logger.info(f"  SKIPPING: Output already exists with correct frame count ({existing_frames})")
                 logger.info(f"  Path: {output_path}")
-                output_paths.append(output_path)
+                output_results[i] = output_path
                 continue
             else:
                 logger.info(f"  Existing output has wrong frame count ({existing_frames} != {expected_frames}), recreating...")
 
-        # Validate paths
         if not config.path.exists():
             raise FileNotFoundError(f"Video file not found: {config.path}")
-
         if not config.timestamps_path.exists():
             raise FileNotFoundError(f"Timestamps file not found: {config.timestamps_path}")
 
-        # Load raw video timestamps
-        raw_video_timestamps = load_video_timestamps(config.timestamps_path)
-        logger.info(f"  Raw video timestamps: {len(raw_video_timestamps)} frames")
-
-        # Normalize video timestamps: convert to seconds and zero
-        video_timestamps = normalize_video_timestamps(
-            video_timestamps=raw_video_timestamps,
-            target_timestamps=common_timestamps_original,
-        )
-
-        logger.info(
-            f"  Normalized video time range: {video_timestamps[0]:.4f}s to {video_timestamps[-1]:.4f}s"
-        )
-        logger.info(
-            f"  Target time range: {common_timestamps_original[0]:.4f}s to {common_timestamps_original[-1]:.4f}s"
-        )
-
-        # Resample the video
-        resample_single_video(
+        worker_arg_list.append((i, VideoResampleArgs(
             video_path=config.path,
-            video_timestamps=video_timestamps,
-            target_timestamps=common_timestamps_original,
+            timestamps_path=config.timestamps_path,
+            common_timestamps_original=common_timestamps_original,
             output_path=output_path,
             video_name=config.name,
             target_fps=target_fps,
-        )
+        )))
 
-        output_paths.append(output_path)
+    if worker_arg_list:
+        num_workers = min(len(worker_arg_list), multiprocessing.cpu_count())
+        logger.info(f"\nResampling {len(worker_arg_list)} videos with {num_workers} workers")
+        with multiprocessing.Pool(processes=num_workers) as pool:
+            processed_paths = pool.map(_resample_video_worker, [args for _, args in worker_arg_list])
+        for (i, _), path in zip(worker_arg_list, processed_paths):
+            output_results[i] = path
+
+    output_paths = [p for p in output_results if p is not None]
 
     logger.info("\n" + "=" * 80)
     logger.info("VIDEO RESAMPLING COMPLETE")

--- a/python_code/rerun_viewer/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/plot_eye_data_quality.py
@@ -94,7 +94,7 @@ def plot_eye_data_quality(recording_folder: RecordingFolder) -> None:
 
 if __name__ == "__main__":
     recording_folder = RecordingFolder.from_folder_path(
-        Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/full_recording")
+        Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/clips/0m_37s-1m_37s")
     )
 
     plot_eye_data_quality(recording_folder=recording_folder)

--- a/python_code/rerun_viewer/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/plot_eye_data_quality.py
@@ -1,0 +1,100 @@
+"""
+Visualize eye data quality: both eye videos with DLC keypoint annotations
+alongside confidence and boolean quality flag timeseries from
+eye_model_v3_mean_confidence.csv.
+
+Layout:
+    Top:    Left Eye Video  |  Right Eye Video
+    Bottom: Left Quality    |  Right Quality
+"""
+from pathlib import Path
+from datetime import datetime
+import numpy as np
+import pandas as pd
+import rerun as rr
+import rerun.blueprint as rrb
+
+from python_code.rerun_viewer.rerun_utils.plot_eye_data_quality import (
+    get_eye_quality_view,
+    log_eye_quality_style,
+    plot_eye_quality,
+)
+from python_code.rerun_viewer.rerun_utils.plot_eye_video import (
+    add_eye_video_context,
+    get_eye_video_views,
+    plot_eye_video,
+    eye_landmarks,
+    eye_connections,
+)
+from python_code.rerun_viewer.rerun_utils.video_data import AlignedEyeVideoData
+from python_code.utilities.folder_utilities.recording_folder import RecordingFolder
+
+
+def plot_eye_data_quality(recording_folder: RecordingFolder) -> None:
+    left_eye = AlignedEyeVideoData.create(
+        annotated_video_path=recording_folder.left_eye_stabilized_canvas,
+        raw_video_path=recording_folder.left_eye_stabilized_canvas,
+        timestamps_npy_path=recording_folder.left_eye_timestamps_npy,
+        data_csv_path=recording_folder.left_eye_plot_points_csv,
+        data_name="Left Eye",
+    )
+
+    right_eye = AlignedEyeVideoData.create(
+        annotated_video_path=recording_folder.right_eye_stabilized_canvas,
+        raw_video_path=recording_folder.right_eye_stabilized_canvas,
+        timestamps_npy_path=recording_folder.right_eye_timestamps_npy,
+        data_csv_path=recording_folder.right_eye_plot_points_csv,
+        data_name="Right Eye",
+    )
+
+    confidence_df = pd.read_csv(recording_folder.eye_mean_confidence)
+
+    # Timestamps relative to recording start, indexed by frame number
+    left_timestamps = left_eye.timestamps - left_eye.timestamps[0]
+    right_timestamps = right_eye.timestamps - right_eye.timestamps[0]
+
+    recording_string = f"{recording_folder.recording_name}_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+    rr.init(recording_string, spawn=True)
+
+    eye_videos_entity_path = "/eye_videos"
+    quality_entity_path = "/quality_plots"
+
+    add_eye_video_context(eye_landmarks, eye_connections, eye_videos_entity_path)
+    log_eye_quality_style("left", quality_entity_path)
+    log_eye_quality_style("right", quality_entity_path)
+
+    video_views = get_eye_video_views(left_eye, right_eye, eye_videos_entity_path)
+    left_quality_view = get_eye_quality_view("left", quality_entity_path)
+    right_quality_view = get_eye_quality_view("right", quality_entity_path)
+
+    blueprint = rrb.Vertical(
+        rrb.Horizontal(*video_views),
+        rrb.Horizontal(left_quality_view, right_quality_view),
+    )
+    rr.send_blueprint(blueprint)
+
+    plot_eye_video(eye_video=left_eye, entity_path=f"{eye_videos_entity_path}/left_eye", landmarks=eye_landmarks)
+    plot_eye_video(eye_video=right_eye, entity_path=f"{eye_videos_entity_path}/right_eye", landmarks=eye_landmarks, flip_horizontal=True)
+
+    plot_eye_quality(
+        eye_name="left",
+        camera_name=recording_folder.left_eye_name,
+        confidence_df=confidence_df,
+        all_timestamps=left_timestamps,
+        entity_path=quality_entity_path,
+    )
+    plot_eye_quality(
+        eye_name="right",
+        camera_name=recording_folder.right_eye_name,
+        confidence_df=confidence_df,
+        all_timestamps=right_timestamps,
+        entity_path=quality_entity_path,
+    )
+
+
+if __name__ == "__main__":
+    recording_folder = RecordingFolder.from_folder_path(
+        Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/full_recording")
+    )
+
+    plot_eye_data_quality(recording_folder=recording_folder)

--- a/python_code/rerun_viewer/rerun_utils/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/rerun_utils/plot_eye_data_quality.py
@@ -1,0 +1,88 @@
+import numpy as np
+import pandas as pd
+import rerun as rr
+import rerun.blueprint as rrb
+
+COLOR_MEAN_CONFIDENCE = [100, 149, 237]   # cornflower blue
+COLOR_BLINK = [255, 165, 0]              # orange
+COLOR_CONFIDENCE = [148, 103, 189]       # purple
+COLOR_POSITION = [44, 160, 44]           # green
+COLOR_GOOD_DATA = [255, 255, 255]        # white
+
+_QUALITY_SERIES: list[tuple[str, list[int]]] = [
+    ("mean_confidence", COLOR_MEAN_CONFIDENCE),
+    ("blink_threshold", COLOR_BLINK),
+    ("confidence_threshold", COLOR_CONFIDENCE),
+    ("eye_position_threshold", COLOR_POSITION),
+    ("good_data", COLOR_GOOD_DATA),
+]
+
+
+def get_eye_quality_view(
+    eye_name: str,
+    entity_path: str = "/",
+    time_window_seconds: float = 5.0,
+) -> rrb.TimeSeriesView:
+    if not entity_path.endswith("/"):
+        entity_path += "/"
+
+    scrolling_time_range = rrb.VisibleTimeRange(
+        "time",
+        start=rrb.TimeRangeBoundary.cursor_relative(seconds=-time_window_seconds),
+        end=rrb.TimeRangeBoundary.cursor_relative(seconds=time_window_seconds),
+    )
+
+    return rrb.TimeSeriesView(
+        name=f"{eye_name.capitalize()} Eye Data Quality",
+        origin=f"{entity_path}quality/{eye_name}_eye",
+        plot_legend=rrb.PlotLegend(visible=True),
+        time_ranges=scrolling_time_range,
+        axis_y=rrb.ScalarAxis(range=(-0.1, 1.1)),
+    )
+
+
+def log_eye_quality_style(eye_name: str, entity_path: str = "/"):
+    if not entity_path.endswith("/"):
+        entity_path += "/"
+    base = f"{entity_path}quality/{eye_name}_eye"
+
+    for series_name, color in _QUALITY_SERIES:
+        rr.log(f"{base}/{series_name}", rr.SeriesLines(widths=1.5, colors=[color]), static=True)
+        rr.log(f"{base}/{series_name}", rr.SeriesPoints(marker_sizes=2.0, colors=[color]), static=True)
+
+
+def plot_eye_quality(
+    eye_name: str,
+    camera_name: str,
+    confidence_df: pd.DataFrame,
+    all_timestamps: np.ndarray,
+    entity_path: str = "/",
+):
+    """
+    Plot eye data quality timeseries for one eye.
+
+    Args:
+        eye_name: "left" or "right" — used for entity path labelling
+        camera_name: "eye0" or "eye1" — matches the camera column in confidence_df
+        confidence_df: DataFrame from eye_model_v3_mean_confidence.csv
+        all_timestamps: 1-D seconds array indexed by frame number (relative to recording start)
+        entity_path: Rerun entity path prefix
+    """
+    if not entity_path.endswith("/"):
+        entity_path += "/"
+    base = f"{entity_path}quality/{eye_name}_eye"
+
+    eye_df = confidence_df[confidence_df["camera"] == camera_name].copy()
+    eye_df = eye_df.sort_values("frames").reset_index(drop=True)
+
+    frame_indices = eye_df["frames"].to_numpy()
+    timestamps = all_timestamps[frame_indices]
+    time_column = rr.TimeColumn("time", duration=timestamps)
+
+    for series_name, _ in _QUALITY_SERIES:
+        values = eye_df[series_name].to_numpy(dtype=float)
+        rr.send_columns(
+            entity_path=f"{base}/{series_name}",
+            indexes=[time_column],
+            columns=rr.Scalars.columns(scalars=values),
+        )

--- a/python_code/rerun_viewer/rerun_utils/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/rerun_utils/plot_eye_data_quality.py
@@ -7,6 +7,7 @@ COLOR_MEAN_CONFIDENCE = [100, 149, 237]   # cornflower blue
 COLOR_BLINK = [255, 165, 0]              # orange
 COLOR_CONFIDENCE = [148, 103, 189]       # purple
 COLOR_POSITION = [44, 160, 44]           # green
+COLOR_DENSITY = [255, 80, 80]            # red
 COLOR_GOOD_DATA = [255, 255, 255]        # white
 
 _QUALITY_SERIES: list[tuple[str, list[int]]] = [
@@ -14,6 +15,7 @@ _QUALITY_SERIES: list[tuple[str, list[int]]] = [
     ("blink_threshold", COLOR_BLINK),
     ("confidence_threshold", COLOR_CONFIDENCE),
     ("eye_position_threshold", COLOR_POSITION),
+    ("density_threshold", COLOR_DENSITY),
     ("good_data", COLOR_GOOD_DATA),
 ]
 

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -43,11 +43,13 @@ def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
         blink_threshold: float = 0.75,
+        blink_trailing_frames: int = 5,
         single_eye_threshold: float = 0.7,
         vertical_threshold: float = 25,
         horizontal_threshold: float = 100,
-        density_window: int = 100,
+        density_window: int = 150,
         max_bad_fraction: float = 0.5,
+        blink_trail_frames: int = 5,
     ) -> pd.DataFrame:
     confidence_df["good_data"] = [1] * len(confidence_df)
     confidence_df["blink_threshold"] = [1] * len(confidence_df)
@@ -65,6 +67,8 @@ def find_bad_eye_data(
     eye0_analysis = analysis_df[eye0_analysis_mask]
     eye1_analysis = analysis_df[eye1_analysis_mask]
 
+    blink_countdown = 0
+
     for frame in confidence_df["frames"].unique():
         frame_mask = confidence_df["frames"]==frame
 
@@ -78,6 +82,12 @@ def find_bad_eye_data(
         if eye0_confidence < blink_threshold and eye1_confidence < blink_threshold:
             confidence_df.loc[frame_mask & eye0_mask, "blink_threshold"] = 0
             confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
+            blink_countdown = blink_trail_frames
+            continue
+        elif blink_countdown > 0:
+            confidence_df.loc[frame_mask & eye0_mask, "blink_threshold"] = 0
+            confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
+            blink_countdown -= 1
             continue
 
         confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, horizontal_threshold, eye0_analysis)

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -42,10 +42,12 @@ def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold
 def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
-        blink_threshold: float = 0.8,
+        blink_threshold: float = 0.75,
         single_eye_threshold: float = 0.7,
         vertical_threshold: float = 25,
         horizontal_threshold: float = 100,
+        density_window: int = 100,
+        max_bad_fraction: float = 0.5,
     ) -> pd.DataFrame:
     confidence_df["good_data"] = [1] * len(confidence_df)
     confidence_df["blink_threshold"] = [1] * len(confidence_df)
@@ -81,7 +83,19 @@ def find_bad_eye_data(
         confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, horizontal_threshold, eye0_analysis)
         confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, horizontal_threshold, eye1_analysis)
 
-    confidence_df["good_data"] = ((confidence_df["blink_threshold"] ==1) & (confidence_df["confidence_threshold"]==1) & (confidence_df["eye_position_threshold"]==1)).astype(int)
+    confidence_df["good_data"] = ((confidence_df["blink_threshold"] == 1) & (confidence_df["confidence_threshold"] == 1) & (confidence_df["eye_position_threshold"] == 1)).astype(int)
+
+    # Density check: mark frames where the surrounding window has too many bad frames.
+    # Done per camera so each eye is evaluated independently.
+    confidence_df["density_threshold"] = 1
+    for camera in confidence_df["camera"].unique():
+        camera_mask = confidence_df["camera"] == camera
+        camera_df = confidence_df[camera_mask].sort_values("frames")
+        bad_fraction = (1 - camera_df["good_data"]).rolling(window=density_window, center=True, min_periods=1).mean()
+        density_ok = (bad_fraction <= max_bad_fraction).astype(int)
+        confidence_df.loc[camera_mask, "density_threshold"] = density_ok.values
+
+    confidence_df["good_data"] = ((confidence_df["blink_threshold"] == 1) & (confidence_df["confidence_threshold"] == 1) & (confidence_df["eye_position_threshold"] == 1) & (confidence_df["density_threshold"] == 1)).astype(int)
 
     return confidence_df
 

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -6,7 +6,7 @@ from time import perf_counter
 from python_code.utilities.get_mean_dlc_confidence import get_mean_dlc_confidence
 
 
-def check_single_eye(frame: int, vertical_threshold: float, analysis_df: pd.DataFrame) -> int:
+def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold: float, analysis_df: pd.DataFrame) -> int:
     filtered_rows = analysis_df[analysis_df["frame"] == frame]
 
     if len(filtered_rows) == 0:
@@ -29,6 +29,8 @@ def check_single_eye(frame: int, vertical_threshold: float, analysis_df: pd.Data
     pupil_center_y = pupil_points['y'].mean()
 
     # Check conditions
+    if (outer_eye_x - tear_duct_x) < horizontal_threshold:
+        return 0
     if pupil_center_x < tear_duct_x or pupil_center_x > outer_eye_x:
         return 0
     if abs(pupil_center_y) > vertical_threshold:
@@ -36,10 +38,14 @@ def check_single_eye(frame: int, vertical_threshold: float, analysis_df: pd.Data
 
     return 1
 
-def find_bad_eye_data(confidence_df: pd.DataFrame, analysis_df: pd.DataFrame):
-    blink_threshold = 0.45
-    single_eye_threshold = 0.4
-    vertical_threshold = 25
+def find_bad_eye_data(
+        confidence_df: pd.DataFrame,
+        analysis_df: pd.DataFrame,
+        blink_threshold: float = 0.8,
+        single_eye_threshold: float = 0.7,
+        vertical_threshold: float = 25,
+        horizontal_threshold: float = 100,
+    ) -> pd.DataFrame:
     confidence_df["good_data"] = [1] * len(confidence_df)
     confidence_df["blink_threshold"] = [1] * len(confidence_df)
     confidence_df["confidence_threshold"] = np.where(confidence_df["mean_confidence"] > single_eye_threshold, 1, 0)
@@ -71,8 +77,8 @@ def find_bad_eye_data(confidence_df: pd.DataFrame, analysis_df: pd.DataFrame):
             confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
             continue
 
-        confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, eye0_analysis)
-        confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, eye1_analysis)
+        confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, horizontal_threshold, eye0_analysis)
+        confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, horizontal_threshold, eye1_analysis)
 
     confidence_df["good_data"] = ((confidence_df["blink_threshold"] ==1) & (confidence_df["confidence_threshold"]==1) & (confidence_df["eye_position_threshold"]==1)).astype(int)
 

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -5,60 +5,35 @@ from time import perf_counter
 
 from python_code.utilities.get_mean_dlc_confidence import get_mean_dlc_confidence
 
-# def check_single_row(row, vertical_threshold: float, analysis_df: pd.DataFrame) -> int:
-#     camera = row["camera"]
-#     if camera == "eye0":
-#         camera = "eye0DLC"
 
-#     frame = row["frames"]
-
-#     mask = (
-#         (analysis_df["frame"] == frame) &
-#         (analysis_df["video"] == camera)
-#     )
-
-#     filtered_rows = analysis_df[mask]
-
-#     tear_duct_row = filtered_rows[filtered_rows["keypoint"] == 'tear_duct']
-#     outer_eye_row = filtered_rows[filtered_rows["keypoint"] == 'outer_eye']
-#     pupil_points = filtered_rows[filtered_rows["keypoint"].isin(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'])]
-    
-#     tear_duct_x = tear_duct_row['x'].iloc[0]
-#     outer_eye_x = outer_eye_row['x'].iloc[0]
-#     pupil_center_x = pupil_points['x'].mean()
-#     pupil_center_y = pupil_points['y'].mean()
-    
-#     if pupil_center_x < tear_duct_x or pupil_center_x > outer_eye_x:
-#         return 0
-#     if abs(pupil_center_y) > vertical_threshold:
-#         return 0
-        
-#     return 1
-
-def check_single_eye(camera: str, frame: int, vertical_threshold: float, analysis_df: pd.DataFrame) -> int:
+def check_single_eye(frame: int, vertical_threshold: float, analysis_df: pd.DataFrame) -> int:
     filtered_rows = analysis_df[analysis_df["frame"] == frame]
-    
+
     if len(filtered_rows) == 0:
-        print(f"Warning: no rows remaining after filtering for frame {frame} camera {camera}")
+        print(f"Warning: no rows remaining after filtering for frame {frame}")
         return 0
-        
+
     # Get keypoints efficiently
     tear_duct_row = filtered_rows[filtered_rows["keypoint"] == 'tear_duct']
     outer_eye_row = filtered_rows[filtered_rows["keypoint"] == 'outer_eye']
     pupil_points = filtered_rows[filtered_rows["keypoint"].isin(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'])]
-    
+
+    if tear_duct_row.empty or outer_eye_row.empty or pupil_points.empty:
+        print(f"Warning: missing keypoints for frame {frame}")
+        return 0
+
     # Extract coordinates directly
     tear_duct_x = tear_duct_row['x'].iloc[0]
     outer_eye_x = outer_eye_row['x'].iloc[0]
     pupil_center_x = pupil_points['x'].mean()
     pupil_center_y = pupil_points['y'].mean()
-    
+
     # Check conditions
     if pupil_center_x < tear_duct_x or pupil_center_x > outer_eye_x:
         return 0
     if abs(pupil_center_y) > vertical_threshold:
         return 0
-        
+
     return 1
 
 def find_bad_eye_data(confidence_df: pd.DataFrame, analysis_df: pd.DataFrame):
@@ -75,23 +50,17 @@ def find_bad_eye_data(confidence_df: pd.DataFrame, analysis_df: pd.DataFrame):
     eye1_confidence_df = confidence_df[eye1_mask]
 
     cleaned_mask = (analysis_df["processing_level"]=="cleaned")
-    # cleaned_analysis_df = analysis_df[cleaned_mask]
-    # confidence_df['eye_position_threshold'] = confidence_df.apply(
-    #     lambda x: check_single_row(x, vertical_threshold=vertical_threshold, analysis_df=cleaned_analysis_df),
-    #     axis=1
-    # )
-    # eye0_analysis_mask = (analysis_df["video"] == "eye0") & cleaned_mask
     eye0_analysis_mask = (analysis_df["video"] == "eye0") & cleaned_mask
     eye1_analysis_mask = (analysis_df["video"] == "eye1") & cleaned_mask
 
     eye0_analysis = analysis_df[eye0_analysis_mask]
     eye1_analysis = analysis_df[eye1_analysis_mask]
 
-    for frame in confidence_df["frames"]:
+    for frame in confidence_df["frames"].unique():
         frame_mask = confidence_df["frames"]==frame
 
-        eye0_row = eye0_confidence_df.loc[frame_mask]
-        eye1_row = eye1_confidence_df.loc[frame_mask]
+        eye0_row = eye0_confidence_df[eye0_confidence_df["frames"] == frame]
+        eye1_row = eye1_confidence_df[eye1_confidence_df["frames"] == frame]
         if len(eye0_row)==0 or len(eye1_row)==0:
             continue
         eye0_confidence = eye0_row.iloc[0]['mean_confidence']
@@ -102,8 +71,8 @@ def find_bad_eye_data(confidence_df: pd.DataFrame, analysis_df: pd.DataFrame):
             confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
             continue
 
-        confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"]=check_single_eye("eye0", frame, vertical_threshold, eye0_analysis)
-        confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"]=check_single_eye("eye1", frame, vertical_threshold, eye1_analysis)
+        confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, eye0_analysis)
+        confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, eye1_analysis)
 
     confidence_df["good_data"] = ((confidence_df["blink_threshold"] ==1) & (confidence_df["confidence_threshold"]==1) & (confidence_df["eye_position_threshold"]==1)).astype(int)
 
@@ -137,6 +106,6 @@ def bad_eye_data(recording_folder: Path):
     print(f"Percent of bad data found was {percent_zeros:.2f}%")
 
 if __name__=='__main__':
-    recording_folder = Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/clips/0m_37s-1m_37s")
+    recording_folder = Path("/Users/philipqueen/session_2025-07-01_ferret_757_EyeCameras_P33_EO5/clips/1m_20s-2m_20s/")
 
     bad_eye_data(recording_folder=recording_folder)

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -43,13 +43,12 @@ def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
         blink_threshold: float = 0.75,
-        blink_trailing_frames: int = 5,
         single_eye_threshold: float = 0.7,
         vertical_threshold: float = 25,
         horizontal_threshold: float = 100,
         density_window: int = 150,
-        max_bad_fraction: float = 0.5,
-        blink_trail_frames: int = 5,
+        max_bad_fraction: float = 0.4,
+        blink_trailing_frames: int = 10,
     ) -> pd.DataFrame:
     confidence_df["good_data"] = [1] * len(confidence_df)
     confidence_df["blink_threshold"] = [1] * len(confidence_df)
@@ -82,7 +81,7 @@ def find_bad_eye_data(
         if eye0_confidence < blink_threshold and eye1_confidence < blink_threshold:
             confidence_df.loc[frame_mask & eye0_mask, "blink_threshold"] = 0
             confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
-            blink_countdown = blink_trail_frames
+            blink_countdown = blink_trailing_frames
             continue
         elif blink_countdown > 0:
             confidence_df.loc[frame_mask & eye0_mask, "blink_threshold"] = 0
@@ -127,7 +126,7 @@ def bad_eye_data(recording_folder: RecordingFolder):
 
 if __name__=='__main__':
     recording_folder = RecordingFolder.from_folder_path(
-        Path("/Users/philipqueen/session_2025-07-01_ferret_757_EyeCameras_P33_EO5/clips/1m_20s-2m_20s/")
+        Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/clips/0m_37s-1m_37s")
     )
 
     bad_eye_data(recording_folder=recording_folder)

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -3,6 +3,7 @@ import numpy as np
 from pathlib import Path
 from time import perf_counter
 
+from python_code.utilities.folder_utilities.recording_folder import RecordingFolder
 from python_code.utilities.get_mean_dlc_confidence import get_mean_dlc_confidence
 
 
@@ -84,24 +85,13 @@ def find_bad_eye_data(
 
     return confidence_df
 
-def bad_eye_data(recording_folder: Path):
-    eye_data_folder = recording_folder / "eye_data"
+def bad_eye_data(recording_folder: RecordingFolder):
+    get_mean_dlc_confidence(recording_folder=recording_folder)
 
-    dlc_path = eye_data_folder / "dlc_output" / "eye_model_v3"
-    synched_video_path = eye_data_folder / "eye_videos"
-    camera_names  = ["eye0", "eye1"]
-
-    get_mean_dlc_confidence(
-        path_to_folder_with_dlc_csvs=dlc_path,
-        path_to_synchronized_video_folder=synched_video_path,
-        camera_names=camera_names
-    )
-
-    dlc_confidence_csv = eye_data_folder / "eye_model_v3_mean_confidence.csv"
-    eye_analysis_output = eye_data_folder / "eye_data.csv"
+    dlc_confidence_csv = recording_folder.eye_data / "eye_model_v3_mean_confidence.csv"
 
     dlc_confidence_df = pd.read_csv(dlc_confidence_csv)
-    eye_analysis_df = pd.read_csv(eye_analysis_output)
+    eye_analysis_df = pd.read_csv(recording_folder.eye_data_csv)
 
     start_time = perf_counter()
     updated_df = find_bad_eye_data(confidence_df=dlc_confidence_df, analysis_df=eye_analysis_df)
@@ -112,6 +102,8 @@ def bad_eye_data(recording_folder: Path):
     print(f"Percent of bad data found was {percent_zeros:.2f}%")
 
 if __name__=='__main__':
-    recording_folder = Path("/Users/philipqueen/session_2025-07-01_ferret_757_EyeCameras_P33_EO5/clips/1m_20s-2m_20s/")
+    recording_folder = RecordingFolder.from_folder_path(
+        Path("/Users/philipqueen/session_2025-07-01_ferret_757_EyeCameras_P33_EO5/clips/1m_20s-2m_20s/")
+    )
 
     bad_eye_data(recording_folder=recording_folder)

--- a/python_code/utilities/get_mean_dlc_confidence.py
+++ b/python_code/utilities/get_mean_dlc_confidence.py
@@ -2,12 +2,16 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 
-def get_mean_dlc_confidence(path_to_folder_with_dlc_csvs: Path, path_to_synchronized_video_folder: Path, camera_names: list[str], save: bool=True):
+from python_code.utilities.folder_utilities.recording_folder import RecordingFolder
+
+
+def get_mean_dlc_confidence(recording_folder: RecordingFolder, save: bool = True):
+    camera_names = [recording_folder.left_eye_name, recording_folder.right_eye_name]
     tidy_confidence_dfs = []
     for camera_name in camera_names:
         camera_confidence_df = get_one_camera_confidence(
-            path_to_folder_with_dlc_csvs=path_to_folder_with_dlc_csvs,
-            path_to_synchronized_video_folder=path_to_synchronized_video_folder,
+            path_to_folder_with_dlc_csvs=recording_folder.eye_dlc_output,
+            path_to_synchronized_video_folder=recording_folder.eye_videos,
             camera_name=camera_name
         )
         tidy_confidence_dfs.append(camera_confidence_df)
@@ -15,7 +19,7 @@ def get_mean_dlc_confidence(path_to_folder_with_dlc_csvs: Path, path_to_synchron
     session_confidence_df = pd.concat(tidy_confidence_dfs, ignore_index=True)
 
     if save:
-        save_path = path_to_synchronized_video_folder.parent / f"{path_to_folder_with_dlc_csvs.stem}_mean_confidence.csv"
+        save_path = recording_folder.eye_data / f"{recording_folder.eye_dlc_output.stem}_mean_confidence.csv"
         session_confidence_df.to_csv(save_path, index=False)
         print(f"mean confidence values saved to {save_path}")
 
@@ -53,14 +57,8 @@ def get_one_camera_confidence(path_to_folder_with_dlc_csvs: Path, path_to_synchr
 
 
 if __name__=="__main__":
-    recording_path = Path("/home/scholl-lab/ferret_recordings/session_2025-10-20_ferret_420_E010/full_recording")
-    data_path = recording_path / "eye_data"
-    dlc_path = data_path / "dlc_output" / "eye_model_v3"
-    synched_video_path = data_path / "eye_videos"
-    camera_names  = ["eye0", "eye1"]
-
-    get_mean_dlc_confidence(
-        path_to_folder_with_dlc_csvs=dlc_path,
-        path_to_synchronized_video_folder=synched_video_path,
-        camera_names=camera_names
+    recording_folder = RecordingFolder.from_folder_path(
+        Path("/home/scholl-lab/ferret_recordings/session_2025-10-20_ferret_420_E010/full_recording")
     )
+
+    get_mean_dlc_confidence(recording_folder=recording_folder)


### PR DESCRIPTION
Some process improvements to decrease processing time. Main goal is to make sure one day's recordings can be fully processed overnight, before the next recording session.

So far, I have parallelized the video creation when synchronizing the Basler cameras (cut 4/5 of the synch timing), and similarly parallelized resampling the videos near the end of the process (cut 1/3 the resample video timing). Those are the main timing improvements.

Aside form that, I have cleaned up the synch a bit, added a timing report to the `full_pipeline.py` file, and made a `batch_pipeline` file that allows running multiple sessions through the pipeline in series.

As of these changes, the timing (for a 5 minute recording) is:
=== Pipeline Timing Summary ===
  Synchronization: 1028.6s (17.1m)
  Calibration: 119.7s (2m)
  Pose estimation: 8450.6s (141m)
  Triangulation: 21.4s (.4m)
  Gaze processing: 7686.8s (128m)
  ---
  Total: 17307.1s (288m)
  
  That means the timing is roughly 1 hour processing per minute of recording
  
  ## TODO:
  - [x] parallelize the eye analysis, in particular the video creation
  - [x] Consider adding a conditional check to DLC pose estimation that only reprocesses if a new model iteration exists. That way when we update one model we don't reprocess all 3.
  

Unfortunately, we don't have many options to speed up the DLC pipeline. Processing multiple at once will be slow because we're already using a large portion of GPU resources