### PR TITLE
Redo eye data quality

### DIFF
--- a/python_code/batch_processing/batch_pipeline.py
+++ b/python_code/batch_processing/batch_pipeline.py
@@ -68,10 +68,10 @@ def batch_full_pipeline(
 if __name__ == "__main__":
     recordings: list[tuple[Path, Path | None]] = [
         # (recording_folder_path, calibration_toml_path or None)
-        (Path("/home/scholl-lab/ferret_recordings/session_2026-03-16_ferret_411_P49_E8"), None),
-        (Path("/home/scholl-lab/ferret_recordings/session_2026-03-10_ferret_411_P43_E2"), None),
-        (Path("/home/scholl-lab/ferret_recordings/session_2026-03-02_ferret_405_EO2"), None),
-        (Path("/home/scholl-lab/ferret_recordings/session_2026-03-09_ferret_407_EO9"), None),
+        (Path("/home/scholl-lab/ferret_recordings/session_2025-06-29_ferret_753_EyeCameras_P31_EO3"), None),
+        (Path("/home/scholl-lab/ferret_recordings/session_2025-07-01_ferret_753_EyeCameras_P33_EO5"), None),
+        (Path("/home/scholl-lab/ferret_recordings/session_2025-10-16_ferret_402_E07"), None),
+        (Path("/home/scholl-lab/ferret_recordings/session_2025-07-09_ferret_753_EyeCameras_P41_E13"), None),
     ]
 
 

--- a/python_code/batch_processing/full_pipeline.py
+++ b/python_code/batch_processing/full_pipeline.py
@@ -325,7 +325,7 @@ if __name__=="__main__":
         overwrite_calibration=False,
         overwrite_dlc=False,
         overwrite_triangulation=False,
-        overwrite_eye_postprocessing=True,
+        overwrite_eye_postprocessing=False,
         overwrite_skull_postprocessing=False,
-        overwrite_gaze=True
+        overwrite_gaze=False
     )

--- a/python_code/batch_processing/full_pipeline.py
+++ b/python_code/batch_processing/full_pipeline.py
@@ -307,7 +307,7 @@ def full_pipeline(
 
 if __name__=="__main__":
     recording_folder_path = Path(
-        "/home/scholl-lab/ferret_recordings/session_2026-03-12_ferret_403_P45_E3"
+        "/home/scholl-lab/ferret_recordings/session_2026-03-07_ferret_407_EO7/full_recording"
     )
 
     if "clips" not in str(recording_folder_path) and "full_recording" not in str(recording_folder_path):
@@ -325,7 +325,7 @@ if __name__=="__main__":
         overwrite_calibration=False,
         overwrite_dlc=False,
         overwrite_triangulation=False,
-        overwrite_eye_postprocessing=False,
+        overwrite_eye_postprocessing=True,
         overwrite_skull_postprocessing=False,
         overwrite_gaze=False
     )

--- a/python_code/batch_processing/postprocess_recording.py
+++ b/python_code/batch_processing/postprocess_recording.py
@@ -24,7 +24,7 @@ def process_recording(
 
     if not skip_skull:
         # process ceres solver
-        run_ferret_skull_solver_from_recording_folder(recording_folder=recording_folder)
+        run_ferret_skull_solver_from_recording_folder(recording_folder=recording_folder, visualize=False)
 
     if not skip_gaze:
         run_gaze_pipeline(

--- a/python_code/eye_analysis/data_processing/align_data/alignment_diagnostics.py
+++ b/python_code/eye_analysis/data_processing/align_data/alignment_diagnostics.py
@@ -109,7 +109,8 @@ def plot_correction_comparison(
         linewidth=1,
         marker='o',
         markersize=2,
-        label='Pupil center'
+        label='Pupil center',
+        rasterized=True
     )
     ax.plot(
         orig_tear[:, 0],
@@ -119,7 +120,8 @@ def plot_correction_comparison(
         marker='s',
         markersize=3,
         label='Tear duct',
-        alpha=0.6
+        alpha=0.6,
+        rasterized=True
     )
     ax.plot(
         orig_outer[:, 0],
@@ -129,7 +131,8 @@ def plot_correction_comparison(
         marker='^',
         markersize=3,
         label='Outer eye',
-        alpha=0.6
+        alpha=0.6,
+        rasterized=True
     )
 
     ax.set_xlabel('X (pixels)')
@@ -149,7 +152,8 @@ def plot_correction_comparison(
         linewidth=1,
         marker='o',
         markersize=2,
-        label='Pupil center'
+        label='Pupil center',
+        rasterized=True
     )
     ax.plot(
         corr_tear[:, 0],
@@ -159,7 +163,8 @@ def plot_correction_comparison(
         marker='s',
         markersize=3,
         label='Tear duct',
-        alpha=0.6
+        alpha=0.6,
+        rasterized=True
     )
     ax.plot(
         corr_outer[:, 0],
@@ -169,7 +174,8 @@ def plot_correction_comparison(
         marker='^',
         markersize=3,
         label='Outer eye',
-        alpha=0.6
+        alpha=0.6,
+        rasterized=True
     )
 
     # Add axis labels for anatomical reference

--- a/python_code/eye_analysis/process_eye_session.py
+++ b/python_code/eye_analysis/process_eye_session.py
@@ -88,6 +88,6 @@ def process_eye_session_from_recording_folder(recording_folder: Path):
 
 
 if __name__ == "__main__":
-    recording_folder = Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/full_recording")
+    recording_folder = Path("/home/scholl-lab/ferret_recordings/session_2025-07-01_ferret_757_EyeCameras_P33_EO5/clips/1m_20s-2m_20s")
 
     process_eye_session_from_recording_folder(recording_folder=recording_folder)

--- a/python_code/eye_analysis/process_eye_session.py
+++ b/python_code/eye_analysis/process_eye_session.py
@@ -27,21 +27,13 @@ def process_eye_session(
     output_data_folder = clip_folder / "eye_data" / "output_data"
     output_data_folder.mkdir(parents=True, exist_ok=True)
 
-    # process eye 0
-    eye_alignment_main(
-        recording_name=f"{recording_name}_{clip_name}_eye0",
-        csv_path=eye_0_dlc_csv,
-        timestamps_path=eye_0_timestamps_npy,
-        output_path=output_data_folder,
-    )
-
-    # process eye 1
-    eye_alignment_main(
-        recording_name=f"{recording_name}_{clip_name}_eye1",
-        csv_path=eye_1_dlc_csv,
-        timestamps_path=eye_1_timestamps_npy,
-        output_path=output_data_folder,
-    )
+    # process both eyes in parallel
+    alignment_args = [
+        (f"{recording_name}_{clip_name}_eye0", eye_0_dlc_csv, eye_0_timestamps_npy, output_data_folder),
+        (f"{recording_name}_{clip_name}_eye1", eye_1_dlc_csv, eye_1_timestamps_npy, output_data_folder),
+    ]
+    with multiprocessing.Pool(processes=2) as pool:
+        pool.starmap(eye_alignment_main, alignment_args)
 
     # merge eye csvs
     merged_eye_output = merge_eye_output_csvs(eye_data_path=clip_folder / "eye_data")

--- a/python_code/eye_analysis/video_viewers/stabilized_eye_viewer.py
+++ b/python_code/eye_analysis/video_viewers/stabilized_eye_viewer.py
@@ -684,7 +684,7 @@ def create_stabilized_eye_videos(base_path: Path, video_path: Path, timestamps_n
     # Create dataset
     print("Loading eye tracking dataset...")
     eye_video_data: EyeVideoData = EyeVideoData.create(
-        data_name="ferret_757_eye_tracking",
+        data_name="eye_tracking",
         recording_path=base_path,
         raw_video_path=video_path,
         timestamps_npy_path=timestamps_npy_path,

--- a/python_code/ferret_gaze/run_gaze_pipeline.py
+++ b/python_code/ferret_gaze/run_gaze_pipeline.py
@@ -81,6 +81,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+import polars as pl
+
 from python_code.ferret_gaze.calculate_gaze.calculate_ferret_gaze import calculate_ferret_gaze
 from python_code.ferret_gaze.data_resampling.data_resampling_helpers import ResamplingStrategy
 from python_code.ferret_gaze.eye_kinematics.ferret_eye_kinematics_functions import (
@@ -93,6 +95,8 @@ from python_code.ferret_gaze.data_resampling.ferret_data_resampler import (
     create_eye_topology,
 )
 from python_code.kinematics_core.reference_geometry_model import ReferenceGeometry
+from python_code.utilities.find_bad_eye_data import save_eye_data_quality_csv
+from python_code.utilities.folder_utilities.recording_folder import RecordingFolder
 
 logging.basicConfig(
     level=logging.INFO,
@@ -567,6 +571,14 @@ def run_gaze_pipeline(
     else:
         logger.info("\n[SKIP] Resampled data already exists")
         logger.info(f"       Location: {paths.analyzable_output_dir}")
+
+    # Save eye data quality CSV now that analyzable_output exists
+    recording_folder = RecordingFolder.from_folder_path(recording_path)
+    if recording_folder.eye_mean_confidence is not None:
+        confidence_df = pl.read_csv(recording_folder.eye_mean_confidence)
+        save_eye_data_quality_csv(recording_folder, confidence_df)
+    else:
+        logger.warning("Eye mean confidence CSV not found — skipping eye data quality export")
 
     # Step 3: Calculate gaze
     if reprocess_gaze or not paths.gaze_kinematics_exists():

--- a/python_code/rerun_viewer/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/plot_eye_data_quality.py
@@ -69,7 +69,7 @@ def plot_eye_data_quality(recording_folder: RecordingFolder) -> None:
 
     blueprint = rrb.Vertical(
         rrb.Horizontal(*video_views),
-        rrb.Horizontal(left_quality_view, right_quality_view),
+        rrb.Horizontal(right_quality_view, left_quality_view),
     )
     rr.send_blueprint(blueprint)
 

--- a/python_code/rerun_viewer/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/plot_eye_data_quality.py
@@ -94,7 +94,7 @@ def plot_eye_data_quality(recording_folder: RecordingFolder) -> None:
 
 if __name__ == "__main__":
     recording_folder = RecordingFolder.from_folder_path(
-        Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/clips/0m_37s-1m_37s")
+        Path("/home/scholl-lab/ferret_recordings/session_2025-07-09_ferret_757_EyeCameras_P41_E13/full_recording")
     )
 
     plot_eye_data_quality(recording_folder=recording_folder)

--- a/python_code/rerun_viewer/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/plot_eye_data_quality.py
@@ -73,9 +73,6 @@ def plot_eye_data_quality(recording_folder: RecordingFolder) -> None:
     )
     rr.send_blueprint(blueprint)
 
-    plot_eye_video(eye_video=left_eye, entity_path=f"{eye_videos_entity_path}/left_eye", landmarks=eye_landmarks)
-    plot_eye_video(eye_video=right_eye, entity_path=f"{eye_videos_entity_path}/right_eye", landmarks=eye_landmarks, flip_horizontal=True)
-
     plot_eye_quality(
         eye_name="left",
         camera_name=recording_folder.left_eye_name,
@@ -90,6 +87,9 @@ def plot_eye_data_quality(recording_folder: RecordingFolder) -> None:
         all_timestamps=right_timestamps,
         entity_path=quality_entity_path,
     )
+
+    plot_eye_video(eye_video=left_eye, entity_path=f"{eye_videos_entity_path}/left_eye", landmarks=eye_landmarks)
+    plot_eye_video(eye_video=right_eye, entity_path=f"{eye_videos_entity_path}/right_eye", landmarks=eye_landmarks, flip_horizontal=True)
 
 
 if __name__ == "__main__":

--- a/python_code/rerun_viewer/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/plot_eye_data_quality.py
@@ -94,7 +94,7 @@ def plot_eye_data_quality(recording_folder: RecordingFolder) -> None:
 
 if __name__ == "__main__":
     recording_folder = RecordingFolder.from_folder_path(
-        Path("/home/scholl-lab/ferret_recordings/session_2025-07-09_ferret_757_EyeCameras_P41_E13/full_recording")
+        Path("/home/scholl-lab/ferret_recordings/session_2025-07-01_ferret_757_EyeCameras_P33_EO5/clips/1m_20s-2m_20s")
     )
 
     plot_eye_data_quality(recording_folder=recording_folder)

--- a/python_code/rerun_viewer/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/plot_eye_data_quality.py
@@ -94,7 +94,7 @@ def plot_eye_data_quality(recording_folder: RecordingFolder) -> None:
 
 if __name__ == "__main__":
     recording_folder = RecordingFolder.from_folder_path(
-        Path("/home/scholl-lab/ferret_recordings/session_2025-07-01_ferret_757_EyeCameras_P33_EO5/clips/1m_20s-2m_20s")
+        Path("/home/scholl-lab/ferret_recordings/session_2026-03-07_ferret_407_EO7/full_recording")
     )
 
     plot_eye_data_quality(recording_folder=recording_folder)

--- a/python_code/rerun_viewer/plot_resampled_data.py
+++ b/python_code/rerun_viewer/plot_resampled_data.py
@@ -88,13 +88,13 @@ def create_rerun_recording(
     log_gaze_trace_style(eye_name=eye_name)
     log_naive_gaze_trace_style(eye_name=eye_name)
 
-    # plot_eye_video(eye_name=eye_name, recording_folder=recording_folder)
-    # plot_3d_eye(eye_name=eye_name, recording_folder=recording_folder)
+    plot_3d_eye(eye_name=eye_name, recording_folder=recording_folder)
     plot_eye_traces(eye_name=eye_name, recording_folder=recording_folder)
     plot_ferret_skull_and_spine_3d(recording_folder=recording_folder) 
     plot_ferret_skull_and_spine_traces(recording_folder=recording_folder)
     plot_gaze_traces(eye_name, recording_folder=recording_folder)
     plot_naive_gaze_traces(eye_name, recording_folder=recording_folder)
+    plot_eye_video(eye_name=eye_name, recording_folder=recording_folder)
 
     print(
         f"Processing complete! Rerun recording '{recording_folder.recording_name}' is ready."
@@ -103,7 +103,7 @@ def create_rerun_recording(
 
 if __name__ == "__main__":
     recording_folder = RecordingFolder.from_folder_path(
-        "/Users/philipqueen/Documents/GitHub/bs/python_code/ferret_gaze/calculate_gaze/synthetic_test_data/combined/full_recording"
+        "/home/scholl-lab/ferret_recordings/session_2026-03-07_ferret_407_EO7/full_recording"
     )
     eye_to_plot = "left"
     create_rerun_recording(

--- a/python_code/rerun_viewer/rerun_utils/gaze_plots/plot_eye_traces.py
+++ b/python_code/rerun_viewer/rerun_utils/gaze_plots/plot_eye_traces.py
@@ -3,7 +3,7 @@ import rerun as rr
 import rerun.blueprint as rrb
 from pathlib import Path
 
-from python_code.ferret_gaze.eye_kinematics.eye_kinematics_rerun_viewer import COLOR_LEFT_EYE_PRIMARY, COLOR_LEFT_EYE_SECONDARY, COLOR_RIGHT_EYE_PRIMARY, COLOR_RIGHT_EYE_SECONDARY, get_eye_radius_from_kinematics, log_static_world_frame, log_timeseries_accelerations, log_timeseries_angles, log_timeseries_velocities, set_time_seconds
+from python_code.ferret_gaze.eye_kinematics.eye_kinematics_rerun_viewer import COLOR_LEFT_EYE_PRIMARY, COLOR_LEFT_EYE_SECONDARY, COLOR_RIGHT_EYE_PRIMARY, COLOR_RIGHT_EYE_SECONDARY
 from python_code.ferret_gaze.eye_kinematics.ferret_eye_kinematics_models import FerretEyeKinematics
 from python_code.utilities.folder_utilities.recording_folder import RecordingFolder
 
@@ -175,18 +175,19 @@ def plot_eye_traces(
     timestamps = timestamps - timestamps[0]
     print(f"Loaded {eye_name} eye kinematics: {kinematics.n_frames} frames")
 
-    for i in range(kinematics.n_frames):
-        set_time_seconds("time", timestamps[i])
-        adduction_deg = np.degrees(kinematics.adduction_angle.values[i])
-        elevation_deg = np.degrees(kinematics.elevation_angle.values[i])
-        adduction_vel = np.degrees(kinematics.adduction_velocity.values[i])
-        elevation_vel = np.degrees(kinematics.elevation_velocity.values[i])
-        adduction_acc = np.degrees(kinematics.adduction_acceleration.values[i])
-        elevation_acc = np.degrees(kinematics.elevation_acceleration.values[i])
+    time_column = rr.TimeColumn("time", duration=timestamps)
+    adduction_deg = np.degrees(kinematics.adduction_angle.values)
+    elevation_deg = np.degrees(kinematics.elevation_angle.values)
+    adduction_vel = np.degrees(kinematics.adduction_velocity.values)
+    elevation_vel = np.degrees(kinematics.elevation_velocity.values)
 
-        log_timeseries_angles(f"{eye_name}_eye", adduction_deg, elevation_deg)
-        log_timeseries_velocities(f"{eye_name}_eye", adduction_vel, elevation_vel)
-        # log_timeseries_accelerations(f"{eye_name}_eye", adduction_acc, elevation_acc)
+    base = f"timeseries/angles/{eye_name}_eye"
+    rr.send_columns(f"{base}/adduction", indexes=[time_column], columns=rr.Scalars.columns(scalars=adduction_deg))
+    rr.send_columns(f"{base}/elevation", indexes=[time_column], columns=rr.Scalars.columns(scalars=elevation_deg))
+
+    base = f"timeseries/velocity/{eye_name}_eye"
+    rr.send_columns(f"{base}/adduction", indexes=[time_column], columns=rr.Scalars.columns(scalars=adduction_vel))
+    rr.send_columns(f"{base}/elevation", indexes=[time_column], columns=rr.Scalars.columns(scalars=elevation_vel))
 
 if __name__ == "__main__":
     from python_code.utilities.folder_utilities.recording_folder import RecordingFolder

--- a/python_code/rerun_viewer/rerun_utils/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/rerun_utils/plot_eye_data_quality.py
@@ -8,7 +8,6 @@ COLOR_BLINK                 = [255, 165, 0]     # orange
 COLOR_BLINK_HIGH            = [255, 100, 0]     # dark orange
 COLOR_COMBINED_BLINK        = [255, 220, 100]   # yellow
 COLOR_COMBINED_BLINK_HIGH   = [200, 160, 0]     # dark yellow
-COLOR_CONFIDENCE_LOW        = [200, 160, 220]   # light purple
 COLOR_CONFIDENCE            = [148, 103, 189]   # purple
 COLOR_CONFIDENCE_HIGH       = [90, 50, 140]     # dark purple
 COLOR_POSITION              = [44, 160, 44]     # green
@@ -18,19 +17,18 @@ COLOR_GOOD_DATA_MEDIUM      = [255, 255, 255]   # white
 COLOR_GOOD_DATA_HIGH        = [100, 220, 100]   # bright green
 
 _QUALITY_SERIES: list[tuple[str, list[int]]] = [
-    ("mean_confidence",             COLOR_MEAN_CONFIDENCE),
-    ("confidence_threshold_low",    COLOR_CONFIDENCE_LOW),
-    ("confidence_threshold",        COLOR_CONFIDENCE),
-    ("confidence_threshold_high",   COLOR_CONFIDENCE_HIGH),
-    ("blink_threshold",             COLOR_BLINK),
-    ("blink_threshold_high",        COLOR_BLINK_HIGH),
-    ("combined_blink_threshold",    COLOR_COMBINED_BLINK),
+    ("mean_confidence",               COLOR_MEAN_CONFIDENCE),
+    ("confidence_threshold",          COLOR_CONFIDENCE),
+    ("confidence_threshold_high",     COLOR_CONFIDENCE_HIGH),
+    ("blink_threshold",               COLOR_BLINK),
+    ("blink_threshold_high",          COLOR_BLINK_HIGH),
+    ("combined_blink_threshold",      COLOR_COMBINED_BLINK),
     ("combined_blink_threshold_high", COLOR_COMBINED_BLINK_HIGH),
-    ("eye_position_threshold",      COLOR_POSITION),
-    ("density_threshold",           COLOR_DENSITY),
-    ("good_data_low",               COLOR_GOOD_DATA_LOW),
-    ("good_data_medium",            COLOR_GOOD_DATA_MEDIUM),
-    ("good_data_high",              COLOR_GOOD_DATA_HIGH),
+    ("eye_position_threshold",        COLOR_POSITION),
+    ("density_threshold",             COLOR_DENSITY),
+    ("good_data_low",                 COLOR_GOOD_DATA_LOW),
+    ("good_data_medium",              COLOR_GOOD_DATA_MEDIUM),
+    ("good_data_high",                COLOR_GOOD_DATA_HIGH),
 ]
 
 
@@ -96,6 +94,9 @@ def plot_eye_quality(
     time_column = rr.TimeColumn("time", duration=timestamps)
 
     for series_name, _ in _QUALITY_SERIES:
+        if series_name not in eye_df.columns:
+            print(f"Warning: column '{series_name}' not found in confidence DataFrame, skipping")
+            continue
         values = eye_df[series_name].to_numpy(dtype=float)
         rr.send_columns(
             entity_path=f"{base}/{series_name}",

--- a/python_code/rerun_viewer/rerun_utils/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/rerun_utils/plot_eye_data_quality.py
@@ -5,6 +5,7 @@ import rerun.blueprint as rrb
 
 COLOR_MEAN_CONFIDENCE = [100, 149, 237]   # cornflower blue
 COLOR_BLINK = [255, 165, 0]              # orange
+COLOR_COMBINED_BLINK = [255, 220, 100]   # yellow
 COLOR_CONFIDENCE = [148, 103, 189]       # purple
 COLOR_POSITION = [44, 160, 44]           # green
 COLOR_DENSITY = [255, 80, 80]            # red
@@ -13,6 +14,7 @@ COLOR_GOOD_DATA = [255, 255, 255]        # white
 _QUALITY_SERIES: list[tuple[str, list[int]]] = [
     ("mean_confidence", COLOR_MEAN_CONFIDENCE),
     ("blink_threshold", COLOR_BLINK),
+    ("combined_blink_threshold", COLOR_COMBINED_BLINK),
     ("confidence_threshold", COLOR_CONFIDENCE),
     ("eye_position_threshold", COLOR_POSITION),
     ("density_threshold", COLOR_DENSITY),

--- a/python_code/rerun_viewer/rerun_utils/plot_eye_data_quality.py
+++ b/python_code/rerun_viewer/rerun_utils/plot_eye_data_quality.py
@@ -3,22 +3,34 @@ import pandas as pd
 import rerun as rr
 import rerun.blueprint as rrb
 
-COLOR_MEAN_CONFIDENCE = [100, 149, 237]   # cornflower blue
-COLOR_BLINK = [255, 165, 0]              # orange
-COLOR_COMBINED_BLINK = [255, 220, 100]   # yellow
-COLOR_CONFIDENCE = [148, 103, 189]       # purple
-COLOR_POSITION = [44, 160, 44]           # green
-COLOR_DENSITY = [255, 80, 80]            # red
-COLOR_GOOD_DATA = [255, 255, 255]        # white
+COLOR_MEAN_CONFIDENCE       = [100, 149, 237]   # cornflower blue
+COLOR_BLINK                 = [255, 165, 0]     # orange
+COLOR_BLINK_HIGH            = [255, 100, 0]     # dark orange
+COLOR_COMBINED_BLINK        = [255, 220, 100]   # yellow
+COLOR_COMBINED_BLINK_HIGH   = [200, 160, 0]     # dark yellow
+COLOR_CONFIDENCE_LOW        = [200, 160, 220]   # light purple
+COLOR_CONFIDENCE            = [148, 103, 189]   # purple
+COLOR_CONFIDENCE_HIGH       = [90, 50, 140]     # dark purple
+COLOR_POSITION              = [44, 160, 44]     # green
+COLOR_DENSITY               = [255, 80, 80]     # red
+COLOR_GOOD_DATA_LOW         = [180, 180, 180]   # light gray
+COLOR_GOOD_DATA_MEDIUM      = [255, 255, 255]   # white
+COLOR_GOOD_DATA_HIGH        = [100, 220, 100]   # bright green
 
 _QUALITY_SERIES: list[tuple[str, list[int]]] = [
-    ("mean_confidence", COLOR_MEAN_CONFIDENCE),
-    ("blink_threshold", COLOR_BLINK),
-    ("combined_blink_threshold", COLOR_COMBINED_BLINK),
-    ("confidence_threshold", COLOR_CONFIDENCE),
-    ("eye_position_threshold", COLOR_POSITION),
-    ("density_threshold", COLOR_DENSITY),
-    ("good_data", COLOR_GOOD_DATA),
+    ("mean_confidence",             COLOR_MEAN_CONFIDENCE),
+    ("confidence_threshold_low",    COLOR_CONFIDENCE_LOW),
+    ("confidence_threshold",        COLOR_CONFIDENCE),
+    ("confidence_threshold_high",   COLOR_CONFIDENCE_HIGH),
+    ("blink_threshold",             COLOR_BLINK),
+    ("blink_threshold_high",        COLOR_BLINK_HIGH),
+    ("combined_blink_threshold",    COLOR_COMBINED_BLINK),
+    ("combined_blink_threshold_high", COLOR_COMBINED_BLINK_HIGH),
+    ("eye_position_threshold",      COLOR_POSITION),
+    ("density_threshold",           COLOR_DENSITY),
+    ("good_data_low",               COLOR_GOOD_DATA_LOW),
+    ("good_data_medium",            COLOR_GOOD_DATA_MEDIUM),
+    ("good_data_high",              COLOR_GOOD_DATA_HIGH),
 ]
 
 

--- a/python_code/rerun_viewer/rerun_utils/process_videos.py
+++ b/python_code/rerun_viewer/rerun_utils/process_videos.py
@@ -1,5 +1,6 @@
 import cv2
 import numpy as np
+from concurrent.futures import ThreadPoolExecutor
 from python_code.rerun_viewer.rerun_utils.video_data import VideoData
 import rerun as rr
 
@@ -36,22 +37,31 @@ def process_video_frames(video_cap: cv2.VideoCapture,
                             resize_width: int,
                             resize_height: int,
                             flip_horizontal: bool = False,
-                            flip_vertical: bool = False) -> list[bytes]:
-    """Process a batch of video frames."""
-    encoded_frames = []
-    success = True
-    while success:
-        success, frame = video_cap.read()
-        if not success:
-            continue
-        encoded_frames.append(process_video_frame(frame=frame,
-                                                    resize_factor=resize_factor,
-                                                    resize_width=resize_width,
-                                                    resize_height=resize_height,
-                                                    flip_horizontal=flip_horizontal,
-                                                    flip_vertical=flip_vertical))
+                            flip_vertical: bool = False,
+                            jpeg_quality: int = 80) -> list[bytes]:
+    """Process video frames in parallel using threads.
 
-    return encoded_frames
+    cv2.imencode releases the GIL, so threads can encode concurrently without
+    pickling frames (unlike ProcessPoolExecutor). Futures are submitted as frames
+    are read so raw arrays are eligible for GC once encoding completes.
+    """
+    futures = []
+    with ThreadPoolExecutor() as executor:
+        success = True
+        while success:
+            success, frame = video_cap.read()
+            if success:
+                futures.append(executor.submit(
+                    process_video_frame,
+                    frame=frame,
+                    resize_factor=resize_factor,
+                    resize_width=resize_width,
+                    resize_height=resize_height,
+                    flip_horizontal=flip_horizontal,
+                    flip_vertical=flip_vertical,
+                    jpeg_quality=jpeg_quality,
+                ))
+    return [f.result() for f in futures]
 
 def process_video(video_data: VideoData, entity_path: str, flip_horizontal: bool = False, flip_vertical: bool = False, include_annotated: bool = True):
     """Process a video and send it to Rerun."""

--- a/python_code/rerun_viewer/rerun_utils/process_videos.py
+++ b/python_code/rerun_viewer/rerun_utils/process_videos.py
@@ -63,6 +63,37 @@ def process_video_frames(video_cap: cv2.VideoCapture,
                 ))
     return [f.result() for f in futures]
 
+
+_MAX_CHUNK_BYTES = 1 * 1024 ** 3  # 1 GB — well under Arrow's 2 GB 32-bit offset limit
+
+
+def _send_encoded_frames_chunked(
+    entity_path: str,
+    timestamps: np.ndarray,
+    encoded_frames: list[bytes],
+) -> None:
+    start = 0
+    while start < len(encoded_frames):
+        end = start
+        chunk_bytes = 0
+        while end < len(encoded_frames):
+            chunk_bytes += len(encoded_frames[end])
+            if chunk_bytes > _MAX_CHUNK_BYTES:
+                break
+            end += 1
+        if end == start:
+            end = start + 1  # always send at least one frame
+        rr.send_columns(
+            entity_path=entity_path,
+            indexes=[rr.TimeColumn("time", duration=timestamps[start:end])],
+            columns=rr.EncodedImage.columns(
+                blob=encoded_frames[start:end],
+                media_type=["image/jpeg"] * (end - start),
+            ),
+        )
+        start = end
+
+
 def process_video(video_data: VideoData, entity_path: str, flip_horizontal: bool = False, flip_vertical: bool = False, include_annotated: bool = True):
     """Process a video and send it to Rerun."""
     print(f"Processing {video_data.data_name} video...")
@@ -79,10 +110,10 @@ def process_video(video_data: VideoData, entity_path: str, flip_horizontal: bool
             flip_vertical=flip_vertical
         )
 
-        rr.send_columns(
+        # Arrow binary arrays use 32-bit offsets, capping total blob size at ~2GB.
+        # Send in chunks to stay safely under that limit.
+        _send_encoded_frames_chunked(
             entity_path=f"{entity_path}/{video_type}",
-            indexes=[rr.TimeColumn("time", duration=timestamps)],
-            columns=rr.EncodedImage.columns(
-                blob=encoded_frames,
-                media_type=['image/jpeg'] * len(encoded_frames))
+            timestamps=timestamps,
+            encoded_frames=encoded_frames,
         )

--- a/python_code/rerun_viewer/rerun_utils/process_videos.py
+++ b/python_code/rerun_viewer/rerun_utils/process_videos.py
@@ -1,5 +1,6 @@
 import cv2
 import numpy as np
+from concurrent.futures import ThreadPoolExecutor
 from python_code.rerun_viewer.rerun_utils.video_data import VideoData
 import rerun as rr
 
@@ -38,20 +39,29 @@ def process_video_frames(video_cap: cv2.VideoCapture,
                             flip_horizontal: bool = False,
                             flip_vertical: bool = False,
                             jpeg_quality: int = 80) -> list[bytes]:
-    """Process a batch of video frames."""
-    encoded_frames = []
-    success = True
-    while success:
-        success, frame = video_cap.read()
-        if not success:
-            continue
-        encoded_frames.append(process_video_frame(frame=frame,
-                                                    resize_factor=resize_factor,
-                                                    resize_width=resize_width,
-                                                    resize_height=resize_height,
-                                                    flip_horizontal=flip_horizontal,
-                                                    flip_vertical=flip_vertical))
-    return encoded_frames
+    """Process video frames in parallel using threads.
+
+    cv2.imencode releases the GIL so threads encode concurrently. frame.copy()
+    is called before submission to ensure each thread owns its frame data
+    independently of OpenCV's internal VideoCapture buffer.
+    """
+    futures = []
+    with ThreadPoolExecutor() as executor:
+        success = True
+        while success:
+            success, frame = video_cap.read()
+            if success:
+                futures.append(executor.submit(
+                    process_video_frame,
+                    frame=frame.copy(),
+                    resize_factor=resize_factor,
+                    resize_width=resize_width,
+                    resize_height=resize_height,
+                    flip_horizontal=flip_horizontal,
+                    flip_vertical=flip_vertical,
+                    jpeg_quality=jpeg_quality,
+                ))
+    return [f.result() for f in futures]
 
 
 _MAX_CHUNK_BYTES = 1 * 1024 ** 3  # 1 GB — well under Arrow's 2 GB 32-bit offset limit

--- a/python_code/rerun_viewer/rerun_utils/process_videos.py
+++ b/python_code/rerun_viewer/rerun_utils/process_videos.py
@@ -1,6 +1,5 @@
 import cv2
 import numpy as np
-from concurrent.futures import ThreadPoolExecutor
 from python_code.rerun_viewer.rerun_utils.video_data import VideoData
 import rerun as rr
 
@@ -39,29 +38,20 @@ def process_video_frames(video_cap: cv2.VideoCapture,
                             flip_horizontal: bool = False,
                             flip_vertical: bool = False,
                             jpeg_quality: int = 80) -> list[bytes]:
-    """Process video frames in parallel using threads.
-
-    cv2.imencode releases the GIL, so threads can encode concurrently without
-    pickling frames (unlike ProcessPoolExecutor). Futures are submitted as frames
-    are read so raw arrays are eligible for GC once encoding completes.
-    """
-    futures = []
-    with ThreadPoolExecutor() as executor:
-        success = True
-        while success:
-            success, frame = video_cap.read()
-            if success:
-                futures.append(executor.submit(
-                    process_video_frame,
-                    frame=frame,
-                    resize_factor=resize_factor,
-                    resize_width=resize_width,
-                    resize_height=resize_height,
-                    flip_horizontal=flip_horizontal,
-                    flip_vertical=flip_vertical,
-                    jpeg_quality=jpeg_quality,
-                ))
-    return [f.result() for f in futures]
+    """Process a batch of video frames."""
+    encoded_frames = []
+    success = True
+    while success:
+        success, frame = video_cap.read()
+        if not success:
+            continue
+        encoded_frames.append(process_video_frame(frame=frame,
+                                                    resize_factor=resize_factor,
+                                                    resize_width=resize_width,
+                                                    resize_height=resize_height,
+                                                    flip_horizontal=flip_horizontal,
+                                                    flip_vertical=flip_vertical))
+    return encoded_frames
 
 
 _MAX_CHUNK_BYTES = 1 * 1024 ** 3  # 1 GB — well under Arrow's 2 GB 32-bit offset limit

--- a/python_code/rigid_body_solver/ferret_skull_solver.py
+++ b/python_code/rigid_body_solver/ferret_skull_solver.py
@@ -309,7 +309,11 @@ def run_ferret_skull_solver(
     return result.kinematics
 
 
-def run_ferret_skull_solver_from_recording_folder(recording_folder: RecordingFolder, reference_video: str = "24676894"):
+def run_ferret_skull_solver_from_recording_folder(
+    recording_folder: RecordingFolder,
+    reference_video: str = "24676894",
+    visualize: bool = True,
+):
     recording_folder.check_triangulation(enforce_toy=False, enforce_annotated=False)
     data_3d_csv = recording_folder.mocap_3d_data / "head_freemocap_data_by_frame.csv"
     synchronized_video_folder = recording_folder.mocap_synchronized_videos
@@ -325,11 +329,12 @@ def run_ferret_skull_solver_from_recording_folder(recording_folder: RecordingFol
         timestamps_path=timestamps_npy,
         output_dir=output_dir,
     )
-    run_ferret_skull_and_spine_visualization(
-        recording_folder=recording_folder,
-        spawn=True,
-        time_window_seconds=5.0,
-    )
+    if visualize:
+        run_ferret_skull_and_spine_visualization(
+            recording_folder=recording_folder,
+            spawn=True,
+            time_window_seconds=5.0,
+        )
 
 
 if __name__ == "__main__":

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -39,16 +39,11 @@ def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold
 
     return 1
 
-def _trimmed_threshold(conf: pd.Series, n_std: float) -> float:
-    """Compute threshold as mean - n_std*std after removing the bottom quartile."""
-    trimmed = conf[conf >= conf.quantile(0.25)]
-    return trimmed.median() - n_std * trimmed.std()
-
-
 def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
         confidence_n_std: float = 3.0,
+        blink_baseline_window: int = 500,
         blink_n_std: float = 3.0,
         blink_trailing_frames: int = 10,
         vertical_threshold: float = 25,
@@ -63,22 +58,26 @@ def find_bad_eye_data(
     eye0_mask = confidence_df["camera"] == "eye0"
     eye1_mask = confidence_df["camera"] == "eye1"
 
-    # Confidence threshold: per-camera, flag frames below trimmed threshold
+    # Confidence threshold: per-camera, flag frames more than confidence_n_std below session mean
     for camera_mask in [eye0_mask, eye1_mask]:
         conf = confidence_df.loc[camera_mask, "mean_confidence"]
-        threshold = _trimmed_threshold(conf, confidence_n_std)
+        threshold = conf.median() - (confidence_n_std * conf.std())
         confidence_df.loc[camera_mask, "confidence_threshold"] = (conf > threshold).astype(int).values
 
-    # Blink detection: both eyes must dip simultaneously below their per-eye trimmed threshold.
+    # Blink detection: both eyes must dip simultaneously below their rolling median baseline.
+    # Dip is normalized by session std so the threshold is session-independent.
     eye0_sorted = confidence_df[eye0_mask].sort_values("frames")
     eye1_sorted = confidence_df[eye1_mask].sort_values("frames")
     eye0_conf = eye0_sorted["mean_confidence"]
     eye1_conf = eye1_sorted["mean_confidence"]
-    eye0_threshold = _trimmed_threshold(eye0_conf, blink_n_std)
-    eye1_threshold = _trimmed_threshold(eye1_conf, blink_n_std)
-    eye0_below = set(eye0_sorted.loc[eye0_conf < eye0_threshold, "frames"])
-    eye1_below = set(eye1_sorted.loc[eye1_conf < eye1_threshold, "frames"])
-    blink_frame_set = eye0_below & eye1_below
+    eye0_dip = (eye0_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye0_conf) / eye0_conf.std()
+    eye1_dip = (eye1_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye1_conf) / eye1_conf.std()
+    eye0_dip_by_frame = dict(zip(eye0_sorted["frames"], eye0_dip))
+    eye1_dip_by_frame = dict(zip(eye1_sorted["frames"], eye1_dip))
+    blink_frame_set = {
+        f for f in eye0_dip_by_frame.keys() & eye1_dip_by_frame.keys()
+        if eye0_dip_by_frame[f] > blink_n_std and eye1_dip_by_frame[f] > blink_n_std
+    }
 
     cleaned_mask = (analysis_df["processing_level"] == "cleaned")
     eye0_analysis = analysis_df[(analysis_df["video"] == "eye0") & cleaned_mask]

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -61,7 +61,7 @@ def find_bad_eye_data(
     # Confidence threshold: per-camera, flag frames more than confidence_n_std below session mean
     for camera_mask in [eye0_mask, eye1_mask]:
         conf = confidence_df.loc[camera_mask, "mean_confidence"]
-        threshold = conf.mean() - confidence_n_std * conf.std()
+        threshold = conf.median() - (confidence_n_std * conf.std())
         confidence_df.loc[camera_mask, "confidence_threshold"] = (conf > threshold).astype(int).values
 
     # Blink detection: both eyes must dip simultaneously below their rolling median baseline.

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -42,9 +42,9 @@ def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold
 def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
-        confidence_n_std: float = 2.0,
+        confidence_n_std: float = 3.0,
         blink_baseline_window: int = 500,
-        blink_n_std: float = 2.0,
+        blink_n_std: float = 3.0,
         blink_trailing_frames: int = 10,
         vertical_threshold: float = 25,
         horizontal_threshold: float = 100,

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -42,43 +42,53 @@ def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold
 def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
-        blink_threshold: float = 0.75,
-        single_eye_threshold: float = 0.7,
+        confidence_n_std: float = 2.0,
+        blink_baseline_window: int = 500,
+        blink_n_std: float = 2.0,
+        blink_trailing_frames: int = 10,
         vertical_threshold: float = 25,
         horizontal_threshold: float = 100,
         density_window: int = 150,
         max_bad_fraction: float = 0.4,
-        blink_trailing_frames: int = 10,
     ) -> pd.DataFrame:
     confidence_df["good_data"] = [1] * len(confidence_df)
     confidence_df["blink_threshold"] = [1] * len(confidence_df)
-    confidence_df["confidence_threshold"] = np.where(confidence_df["mean_confidence"] > single_eye_threshold, 1, 0)
+    confidence_df["confidence_threshold"] = [1] * len(confidence_df)
     confidence_df["eye_position_threshold"] = [1] * len(confidence_df)
-    eye0_mask = confidence_df["camera"]=="eye0"
-    eye1_mask = confidence_df["camera"]=="eye1"
-    eye0_confidence_df = confidence_df[eye0_mask]
-    eye1_confidence_df = confidence_df[eye1_mask]
+    eye0_mask = confidence_df["camera"] == "eye0"
+    eye1_mask = confidence_df["camera"] == "eye1"
 
-    cleaned_mask = (analysis_df["processing_level"]=="cleaned")
-    eye0_analysis_mask = (analysis_df["video"] == "eye0") & cleaned_mask
-    eye1_analysis_mask = (analysis_df["video"] == "eye1") & cleaned_mask
+    # Confidence threshold: per-camera, flag frames more than confidence_n_std below session mean
+    for camera_mask in [eye0_mask, eye1_mask]:
+        conf = confidence_df.loc[camera_mask, "mean_confidence"]
+        threshold = conf.mean() - confidence_n_std * conf.std()
+        confidence_df.loc[camera_mask, "confidence_threshold"] = (conf > threshold).astype(int).values
 
-    eye0_analysis = analysis_df[eye0_analysis_mask]
-    eye1_analysis = analysis_df[eye1_analysis_mask]
+    # Blink detection: both eyes must dip simultaneously below their rolling median baseline.
+    # Dip is normalized by session std so the threshold is session-independent.
+    eye0_sorted = confidence_df[eye0_mask].sort_values("frames")
+    eye1_sorted = confidence_df[eye1_mask].sort_values("frames")
+    eye0_conf = eye0_sorted["mean_confidence"]
+    eye1_conf = eye1_sorted["mean_confidence"]
+    eye0_dip = (eye0_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye0_conf) / eye0_conf.std()
+    eye1_dip = (eye1_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye1_conf) / eye1_conf.std()
+    eye0_dip_by_frame = dict(zip(eye0_sorted["frames"], eye0_dip))
+    eye1_dip_by_frame = dict(zip(eye1_sorted["frames"], eye1_dip))
+    blink_frame_set = {
+        f for f in eye0_dip_by_frame.keys() & eye1_dip_by_frame.keys()
+        if eye0_dip_by_frame[f] > blink_n_std and eye1_dip_by_frame[f] > blink_n_std
+    }
+
+    cleaned_mask = (analysis_df["processing_level"] == "cleaned")
+    eye0_analysis = analysis_df[(analysis_df["video"] == "eye0") & cleaned_mask]
+    eye1_analysis = analysis_df[(analysis_df["video"] == "eye1") & cleaned_mask]
 
     blink_countdown = 0
 
-    for frame in confidence_df["frames"].unique():
-        frame_mask = confidence_df["frames"]==frame
+    for frame in sorted(confidence_df["frames"].unique()):
+        frame_mask = confidence_df["frames"] == frame
 
-        eye0_row = eye0_confidence_df[eye0_confidence_df["frames"] == frame]
-        eye1_row = eye1_confidence_df[eye1_confidence_df["frames"] == frame]
-        if len(eye0_row)==0 or len(eye1_row)==0:
-            continue
-        eye0_confidence = eye0_row.iloc[0]['mean_confidence']
-        eye1_confidence = eye1_row.iloc[0]['mean_confidence']
-
-        if eye0_confidence < blink_threshold and eye1_confidence < blink_threshold:
+        if frame in blink_frame_set:
             confidence_df.loc[frame_mask & eye0_mask, "blink_threshold"] = 0
             confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
             blink_countdown = blink_trailing_frames
@@ -89,8 +99,8 @@ def find_bad_eye_data(
             blink_countdown -= 1
             continue
 
-        confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, horizontal_threshold, eye0_analysis)
-        confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"]=check_single_eye(frame, vertical_threshold, horizontal_threshold, eye1_analysis)
+        confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"] = check_single_eye(frame, vertical_threshold, horizontal_threshold, eye0_analysis)
+        confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"] = check_single_eye(frame, vertical_threshold, horizontal_threshold, eye1_analysis)
 
     confidence_df["good_data"] = ((confidence_df["blink_threshold"] == 1) & (confidence_df["confidence_threshold"] == 1) & (confidence_df["eye_position_threshold"] == 1)).astype(int)
 

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -39,11 +39,16 @@ def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold
 
     return 1
 
+def _trimmed_threshold(conf: pd.Series, n_std: float) -> float:
+    """Compute threshold as mean - n_std*std after removing the bottom quartile."""
+    trimmed = conf[conf >= conf.quantile(0.25)]
+    return trimmed.median() - n_std * trimmed.std()
+
+
 def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
         confidence_n_std: float = 3.0,
-        blink_baseline_window: int = 500,
         blink_n_std: float = 3.0,
         blink_trailing_frames: int = 10,
         vertical_threshold: float = 25,
@@ -58,26 +63,22 @@ def find_bad_eye_data(
     eye0_mask = confidence_df["camera"] == "eye0"
     eye1_mask = confidence_df["camera"] == "eye1"
 
-    # Confidence threshold: per-camera, flag frames more than confidence_n_std below session mean
+    # Confidence threshold: per-camera, flag frames below trimmed threshold
     for camera_mask in [eye0_mask, eye1_mask]:
         conf = confidence_df.loc[camera_mask, "mean_confidence"]
-        threshold = conf.median() - (confidence_n_std * conf.std())
+        threshold = _trimmed_threshold(conf, confidence_n_std)
         confidence_df.loc[camera_mask, "confidence_threshold"] = (conf > threshold).astype(int).values
 
-    # Blink detection: both eyes must dip simultaneously below their rolling median baseline.
-    # Dip is normalized by session std so the threshold is session-independent.
+    # Blink detection: both eyes must dip simultaneously below their per-eye trimmed threshold.
     eye0_sorted = confidence_df[eye0_mask].sort_values("frames")
     eye1_sorted = confidence_df[eye1_mask].sort_values("frames")
     eye0_conf = eye0_sorted["mean_confidence"]
     eye1_conf = eye1_sorted["mean_confidence"]
-    eye0_dip = (eye0_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye0_conf) / eye0_conf.std()
-    eye1_dip = (eye1_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye1_conf) / eye1_conf.std()
-    eye0_dip_by_frame = dict(zip(eye0_sorted["frames"], eye0_dip))
-    eye1_dip_by_frame = dict(zip(eye1_sorted["frames"], eye1_dip))
-    blink_frame_set = {
-        f for f in eye0_dip_by_frame.keys() & eye1_dip_by_frame.keys()
-        if eye0_dip_by_frame[f] > blink_n_std and eye1_dip_by_frame[f] > blink_n_std
-    }
+    eye0_threshold = _trimmed_threshold(eye0_conf, blink_n_std)
+    eye1_threshold = _trimmed_threshold(eye1_conf, blink_n_std)
+    eye0_below = set(eye0_sorted.loc[eye0_conf < eye0_threshold, "frames"])
+    eye1_below = set(eye1_sorted.loc[eye1_conf < eye1_threshold, "frames"])
+    blink_frame_set = eye0_below & eye1_below
 
     cleaned_mask = (analysis_df["processing_level"] == "cleaned")
     eye0_analysis = analysis_df[(analysis_df["video"] == "eye0") & cleaned_mask]

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import polars as pl
 from pathlib import Path
 from time import perf_counter
 
@@ -194,6 +195,46 @@ def find_bad_eye_data(
     return confidence_df
 
 
+def save_eye_data_quality_csv(recording_folder: RecordingFolder, confidence_df: pd.DataFrame) -> None:
+    analyzable_output = recording_folder.folder_path / "analyzable_output"
+    analyzable_output.mkdir(exist_ok=True, parents=True)
+
+    eye_to_trajectory = {
+        recording_folder.left_eye_name:  "left_eye_data_quality",
+        recording_folder.right_eye_name: "right_eye_data_quality",
+    }
+    component_map = {
+        "good_data_low":    "low_threshold",
+        "good_data_medium": "medium_threshold",
+        "good_data_high":   "high_threshold",
+    }
+
+    chunks = []
+    for camera_name, trajectory_name in eye_to_trajectory.items():
+        eye_df = confidence_df[confidence_df["camera"] == camera_name][
+            ["frames", "timestamps", "good_data_low", "good_data_medium", "good_data_high"]
+        ]
+        chunk = (
+            pl.from_pandas(eye_df)
+            .rename({"frames": "frame", "timestamps": "timestamp_s"})
+            .unpivot(
+                on=["good_data_low", "good_data_medium", "good_data_high"],
+                index=["frame", "timestamp_s"],
+                variable_name="component",
+                value_name="value",
+            )
+            .with_columns([
+                pl.col("component").replace(component_map).cast(pl.Categorical),
+                pl.lit(trajectory_name).alias("trajectory").cast(pl.Categorical),
+                pl.lit("boolean").alias("units").cast(pl.Categorical),
+            ])
+            .select(["frame", "timestamp_s", "trajectory", "component", "value", "units"])
+        )
+        chunks.append(chunk)
+
+    pl.concat(chunks).write_csv(analyzable_output / "eye_data_quality.csv")
+
+
 def bad_eye_data(recording_folder: RecordingFolder):
     get_mean_dlc_confidence(recording_folder=recording_folder)
 
@@ -206,6 +247,7 @@ def bad_eye_data(recording_folder: RecordingFolder):
     end_time = perf_counter()
 
     updated_df.to_csv(dlc_confidence_csv, index=False)
+    save_eye_data_quality_csv(recording_folder, updated_df)
     print(f"Searching for eye data took {end_time - start_time} s")
     for level in ("low", "medium", "high"):
         pct = (updated_df[f"good_data_{level}"] == 0).mean() * 100

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -195,9 +195,8 @@ def find_bad_eye_data(
     return confidence_df
 
 
-def save_eye_data_quality_csv(recording_folder: RecordingFolder, confidence_df: pd.DataFrame) -> None:
+def save_eye_data_quality_csv(recording_folder: RecordingFolder, confidence_df: pl.DataFrame) -> None:
     analyzable_output = recording_folder.folder_path / "analyzable_output"
-    analyzable_output.mkdir(exist_ok=True, parents=True)
 
     eye_to_trajectory = {
         recording_folder.left_eye_name:  "left_eye_data_quality",
@@ -211,11 +210,10 @@ def save_eye_data_quality_csv(recording_folder: RecordingFolder, confidence_df: 
 
     chunks = []
     for camera_name, trajectory_name in eye_to_trajectory.items():
-        eye_df = confidence_df[confidence_df["camera"] == camera_name][
-            ["frames", "timestamps", "good_data_low", "good_data_medium", "good_data_high"]
-        ]
         chunk = (
-            pl.from_pandas(eye_df)
+            confidence_df
+            .filter(pl.col("camera") == camera_name)
+            .select(["frames", "timestamps", "good_data_low", "good_data_medium", "good_data_high"])
             .rename({"frames": "frame", "timestamps": "timestamp_s"})
             .unpivot(
                 on=["good_data_low", "good_data_medium", "good_data_high"],
@@ -247,7 +245,6 @@ def bad_eye_data(recording_folder: RecordingFolder):
     end_time = perf_counter()
 
     updated_df.to_csv(dlc_confidence_csv, index=False)
-    save_eye_data_quality_csv(recording_folder, updated_df)
     print(f"Searching for eye data took {end_time - start_time} s")
     for level in ("low", "medium", "high"):
         pct = (updated_df[f"good_data_{level}"] == 0).mean() * 100

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -56,47 +56,71 @@ def _find_blink_frames(eye_sorted: pd.DataFrame, drop_threshold: float, n_recove
 def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
+        # Low-level params (loose — fewest frames rejected)
+        confidence_n_std_low: float = 6.0,
+        # Medium-level params (current defaults)
         confidence_n_std: float = 4.0,
         blink_drop_n_std: float = 1.0,
+        blink_n_std: float = 3.0,
+        # High-level params (strict — most frames rejected)
+        confidence_n_std_high: float = 3.0,
+        blink_drop_n_std_high: float = 0.7,
+        blink_n_std_high: float = 2.0,
+        # Shared params
         blink_n_recovery_frames: int = 3,
         blink_baseline_window: int = 500,
-        blink_n_std: float = 3.0,
         blink_trailing_frames: int = 10,
         vertical_threshold: float = 25,
         horizontal_threshold: float = 100,
         density_window: int = 150,
         max_bad_fraction: float = 0.4,
     ) -> pd.DataFrame:
-    confidence_df["good_data"] = 1
-    confidence_df["blink_threshold"] = 1
-    confidence_df["combined_blink_threshold"] = 1
+    confidence_df["confidence_threshold_low"] = 1
     confidence_df["confidence_threshold"] = 1
+    confidence_df["confidence_threshold_high"] = 1
+    confidence_df["blink_threshold"] = 1
+    confidence_df["blink_threshold_high"] = 1
+    confidence_df["combined_blink_threshold"] = 1
+    confidence_df["combined_blink_threshold_high"] = 1
     confidence_df["eye_position_threshold"] = 1
     eye0_mask = confidence_df["camera"] == "eye0"
     eye1_mask = confidence_df["camera"] == "eye1"
 
-    # Confidence threshold: per-camera, flag frames more than confidence_n_std below session median
+    # Confidence thresholds: all three levels computed per-camera in one pass
     for camera_mask in [eye0_mask, eye1_mask]:
         conf = confidence_df.loc[camera_mask, "mean_confidence"]
-        threshold = conf[conf >= conf.quantile(0.10)].median() - (confidence_n_std * conf.std())
-        confidence_df.loc[camera_mask, "confidence_threshold"] = (conf > threshold).astype(int).values
+        trimmed_median = conf[conf >= conf.quantile(0.10)].median()
+        std = conf.std()
+        confidence_df.loc[camera_mask, "confidence_threshold_low"]  = (conf > trimmed_median - confidence_n_std_low  * std).astype(int).values
+        confidence_df.loc[camera_mask, "confidence_threshold"]      = (conf > trimmed_median - confidence_n_std      * std).astype(int).values
+        confidence_df.loc[camera_mask, "confidence_threshold_high"] = (conf > trimmed_median - confidence_n_std_high * std).astype(int).values
 
-    # Per-eye blink detection: shape-based — two consecutive steep drops then recovery below onset
+    # Per-eye shape-based blink detection at medium and high params
     eye0_sorted = confidence_df[eye0_mask].sort_values("frames").reset_index(drop=True)
     eye1_sorted = confidence_df[eye1_mask].sort_values("frames").reset_index(drop=True)
-    eye0_blink_frames = _find_blink_frames(eye0_sorted, blink_drop_n_std * eye0_sorted["mean_confidence"].std(), blink_n_recovery_frames)
-    eye1_blink_frames = _find_blink_frames(eye1_sorted, blink_drop_n_std * eye1_sorted["mean_confidence"].std(), blink_n_recovery_frames)
+    eye0_std = eye0_sorted["mean_confidence"].std()
+    eye1_std = eye1_sorted["mean_confidence"].std()
 
-    # Combined blink detection: both eyes must dip simultaneously below their rolling median baseline
+    eye0_blink_frames = _find_blink_frames(eye0_sorted, blink_drop_n_std * eye0_std, blink_n_recovery_frames)
+    eye1_blink_frames = _find_blink_frames(eye1_sorted, blink_drop_n_std * eye1_std, blink_n_recovery_frames)
+    eye0_blink_frames_high = _find_blink_frames(eye0_sorted, blink_drop_n_std_high * eye0_std, blink_n_recovery_frames)
+    eye1_blink_frames_high = _find_blink_frames(eye1_sorted, blink_drop_n_std_high * eye1_std, blink_n_recovery_frames)
+
+    # Combined blink detection (both eyes simultaneously) at medium and high params
     eye0_conf = eye0_sorted["mean_confidence"]
     eye1_conf = eye1_sorted["mean_confidence"]
     eye0_dip = (eye0_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye0_conf) / eye0_conf.std()
     eye1_dip = (eye1_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye1_conf) / eye1_conf.std()
     eye0_dip_by_frame = dict(zip(eye0_sorted["frames"], eye0_dip))
     eye1_dip_by_frame = dict(zip(eye1_sorted["frames"], eye1_dip))
+    shared_frames = eye0_dip_by_frame.keys() & eye1_dip_by_frame.keys()
     combined_blink_frame_set = {
-        f for f in eye0_dip_by_frame.keys() & eye1_dip_by_frame.keys()
+        f for f in shared_frames
         if eye0_dip_by_frame[f] > blink_n_std and eye1_dip_by_frame[f] > blink_n_std
+    }
+    combined_blink_frame_set_high = {
+        f for f in shared_frames
+        if eye0_dip_by_frame[f] > blink_n_std_high and eye1_dip_by_frame[f] > blink_n_std_high
     }
 
     cleaned_mask = analysis_df["processing_level"] == "cleaned"
@@ -105,13 +129,19 @@ def find_bad_eye_data(
 
     eye0_blink_countdown = 0
     eye1_blink_countdown = 0
+    eye0_blink_countdown_high = 0
+    eye1_blink_countdown_high = 0
     combined_blink_countdown = 0
+    combined_blink_countdown_high = 0
 
     for frame in sorted(confidence_df["frames"].unique()):
         frame_mask = confidence_df["frames"] == frame
         eye0_is_blink = frame in eye0_blink_frames
         eye1_is_blink = frame in eye1_blink_frames
+        eye0_is_blink_high = frame in eye0_blink_frames_high
+        eye1_is_blink_high = frame in eye1_blink_frames_high
 
+        # Medium per-eye blink
         if eye0_is_blink:
             confidence_df.loc[frame_mask & eye0_mask, "blink_threshold"] = 0
             eye0_blink_countdown = blink_trailing_frames
@@ -126,6 +156,22 @@ def find_bad_eye_data(
             confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
             eye1_blink_countdown -= 1
 
+        # High per-eye blink
+        if eye0_is_blink_high:
+            confidence_df.loc[frame_mask & eye0_mask, "blink_threshold_high"] = 0
+            eye0_blink_countdown_high = blink_trailing_frames
+        elif eye0_blink_countdown_high > 0:
+            confidence_df.loc[frame_mask & eye0_mask, "blink_threshold_high"] = 0
+            eye0_blink_countdown_high -= 1
+
+        if eye1_is_blink_high:
+            confidence_df.loc[frame_mask & eye1_mask, "blink_threshold_high"] = 0
+            eye1_blink_countdown_high = blink_trailing_frames
+        elif eye1_blink_countdown_high > 0:
+            confidence_df.loc[frame_mask & eye1_mask, "blink_threshold_high"] = 0
+            eye1_blink_countdown_high -= 1
+
+        # Combined medium blink
         if frame in combined_blink_frame_set:
             confidence_df.loc[frame_mask & eye0_mask, "combined_blink_threshold"] = 0
             confidence_df.loc[frame_mask & eye1_mask, "combined_blink_threshold"] = 0
@@ -135,30 +181,51 @@ def find_bad_eye_data(
             confidence_df.loc[frame_mask & eye1_mask, "combined_blink_threshold"] = 0
             combined_blink_countdown -= 1
 
+        # Combined high blink
+        if frame in combined_blink_frame_set_high:
+            confidence_df.loc[frame_mask & eye0_mask, "combined_blink_threshold_high"] = 0
+            confidence_df.loc[frame_mask & eye1_mask, "combined_blink_threshold_high"] = 0
+            combined_blink_countdown_high = blink_trailing_frames
+        elif combined_blink_countdown_high > 0:
+            confidence_df.loc[frame_mask & eye0_mask, "combined_blink_threshold_high"] = 0
+            confidence_df.loc[frame_mask & eye1_mask, "combined_blink_threshold_high"] = 0
+            combined_blink_countdown_high -= 1
+
+        # Eye position — computed once per frame, skipped during medium blink windows
         if not eye0_is_blink and eye0_blink_countdown == 0:
             confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"] = check_single_eye(frame, vertical_threshold, horizontal_threshold, eye0_analysis)
         if not eye1_is_blink and eye1_blink_countdown == 0:
             confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"] = check_single_eye(frame, vertical_threshold, horizontal_threshold, eye1_analysis)
 
-    confidence_df["good_data"] = (
-        (confidence_df["blink_threshold"] == 1)
+    # Compute density from the medium-level pre-density good_data
+    good_data_medium_pre_density = (
+        (confidence_df["confidence_threshold"] == 1)
+        & (confidence_df["blink_threshold"] == 1)
         & (confidence_df["combined_blink_threshold"] == 1)
-        & (confidence_df["confidence_threshold"] == 1)
         & (confidence_df["eye_position_threshold"] == 1)
-    ).astype(int)
-
-    # Density check: mark frames where the surrounding window has too many bad frames, per camera
+    )
     confidence_df["density_threshold"] = 1
     for camera in confidence_df["camera"].unique():
         camera_mask = confidence_df["camera"] == camera
-        camera_df = confidence_df[camera_mask].sort_values("frames")
-        bad_fraction = (1 - camera_df["good_data"]).rolling(window=density_window, center=True, min_periods=1).mean()
+        camera_df = good_data_medium_pre_density[camera_mask].reset_index(drop=True)
+        bad_fraction = (1 - camera_df).rolling(window=density_window, center=True, min_periods=1).mean()
         confidence_df.loc[camera_mask, "density_threshold"] = (bad_fraction <= max_bad_fraction).astype(int).values
 
-    confidence_df["good_data"] = (
-        (confidence_df["blink_threshold"] == 1)
-        & (confidence_df["combined_blink_threshold"] == 1)
-        & (confidence_df["confidence_threshold"] == 1)
+    # Final good_data columns for each level
+    confidence_df["good_data_low"] = (
+        (confidence_df["confidence_threshold_low"] == 1)
+        & (confidence_df["eye_position_threshold"] == 1)
+    ).astype(int)
+
+    confidence_df["good_data_medium"] = (
+        good_data_medium_pre_density
+        & (confidence_df["density_threshold"] == 1)
+    ).astype(int)
+
+    confidence_df["good_data_high"] = (
+        (confidence_df["confidence_threshold_high"] == 1)
+        & (confidence_df["blink_threshold_high"] == 1)
+        & (confidence_df["combined_blink_threshold_high"] == 1)
         & (confidence_df["eye_position_threshold"] == 1)
         & (confidence_df["density_threshold"] == 1)
     ).astype(int)
@@ -179,8 +246,9 @@ def bad_eye_data(recording_folder: RecordingFolder):
 
     updated_df.to_csv(dlc_confidence_csv, index=False)
     print(f"Searching for eye data took {end_time - start_time} s")
-    percent_zeros = (updated_df['good_data'] == 0).mean() * 100
-    print(f"Percent of bad data found was {percent_zeros:.2f}%")
+    for level in ("low", "medium", "high"):
+        pct = (updated_df[f"good_data_{level}"] == 0).mean() * 100
+        print(f"  {level}: {pct:.2f}% bad")
 
 
 if __name__ == '__main__':

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import numpy as np
 from pathlib import Path
 from time import perf_counter
 
@@ -14,7 +13,6 @@ def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold
         print(f"Warning: no rows remaining after filtering for frame {frame}")
         return 0
 
-    # Get keypoints efficiently
     tear_duct_row = filtered_rows[filtered_rows["keypoint"] == 'tear_duct']
     outer_eye_row = filtered_rows[filtered_rows["keypoint"] == 'outer_eye']
     pupil_points = filtered_rows[filtered_rows["keypoint"].isin(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'])]
@@ -23,13 +21,11 @@ def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold
         print(f"Warning: missing keypoints for frame {frame}")
         return 0
 
-    # Extract coordinates directly
     tear_duct_x = tear_duct_row['x'].iloc[0]
     outer_eye_x = outer_eye_row['x'].iloc[0]
     pupil_center_x = pupil_points['x'].mean()
     pupil_center_y = pupil_points['y'].mean()
 
-    # Check conditions
     if (outer_eye_x - tear_duct_x) < horizontal_threshold:
         return 0
     if pupil_center_x < tear_duct_x or pupil_center_x > outer_eye_x:
@@ -39,10 +35,30 @@ def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold
 
     return 1
 
+
+def _find_blink_frames(eye_sorted: pd.DataFrame, drop_threshold: float, n_recovery: int) -> set:
+    conf = eye_sorted["mean_confidence"].tolist()
+    frames = eye_sorted["frames"].tolist()
+    diff = [0.0] + [conf[i] - conf[i - 1] for i in range(1, len(conf))]
+    bad_frames = set()
+    for i in range(1, len(diff) - 1):
+        if diff[i] < -drop_threshold and diff[i + 1] < -drop_threshold:
+            onset_conf = conf[i]
+            bad_frames.add(frames[i])
+            if i + 1 < len(frames):
+                bad_frames.add(frames[i + 1])
+            for j in range(i + 2, min(i + 2 + n_recovery, len(frames))):
+                if conf[j] < onset_conf:
+                    bad_frames.add(frames[j])
+    return bad_frames
+
+
 def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
         confidence_n_std: float = 4.0,
+        blink_drop_n_std: float = 1.0,
+        blink_n_recovery_frames: int = 3,
         blink_baseline_window: int = 500,
         blink_n_std: float = 3.0,
         blink_trailing_frames: int = 10,
@@ -51,90 +67,123 @@ def find_bad_eye_data(
         density_window: int = 150,
         max_bad_fraction: float = 0.4,
     ) -> pd.DataFrame:
-    confidence_df["good_data"] = [1] * len(confidence_df)
-    confidence_df["blink_threshold"] = [1] * len(confidence_df)
-    confidence_df["confidence_threshold"] = [1] * len(confidence_df)
-    confidence_df["eye_position_threshold"] = [1] * len(confidence_df)
+    confidence_df["good_data"] = 1
+    confidence_df["blink_threshold"] = 1
+    confidence_df["combined_blink_threshold"] = 1
+    confidence_df["confidence_threshold"] = 1
+    confidence_df["eye_position_threshold"] = 1
     eye0_mask = confidence_df["camera"] == "eye0"
     eye1_mask = confidence_df["camera"] == "eye1"
 
-    # Confidence threshold: per-camera, flag frames more than confidence_n_std below session mean
+    # Confidence threshold: per-camera, flag frames more than confidence_n_std below session median
     for camera_mask in [eye0_mask, eye1_mask]:
         conf = confidence_df.loc[camera_mask, "mean_confidence"]
         threshold = conf[conf >= conf.quantile(0.10)].median() - (confidence_n_std * conf.std())
         confidence_df.loc[camera_mask, "confidence_threshold"] = (conf > threshold).astype(int).values
 
-    # Blink detection: both eyes must dip simultaneously below their rolling median baseline.
-    # Dip is normalized by session std so the threshold is session-independent.
-    eye0_sorted = confidence_df[eye0_mask].sort_values("frames")
-    eye1_sorted = confidence_df[eye1_mask].sort_values("frames")
+    # Per-eye blink detection: shape-based — two consecutive steep drops then recovery below onset
+    eye0_sorted = confidence_df[eye0_mask].sort_values("frames").reset_index(drop=True)
+    eye1_sorted = confidence_df[eye1_mask].sort_values("frames").reset_index(drop=True)
+    eye0_blink_frames = _find_blink_frames(eye0_sorted, blink_drop_n_std * eye0_sorted["mean_confidence"].std(), blink_n_recovery_frames)
+    eye1_blink_frames = _find_blink_frames(eye1_sorted, blink_drop_n_std * eye1_sorted["mean_confidence"].std(), blink_n_recovery_frames)
+
+    # Combined blink detection: both eyes must dip simultaneously below their rolling median baseline
     eye0_conf = eye0_sorted["mean_confidence"]
     eye1_conf = eye1_sorted["mean_confidence"]
     eye0_dip = (eye0_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye0_conf) / eye0_conf.std()
     eye1_dip = (eye1_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye1_conf) / eye1_conf.std()
     eye0_dip_by_frame = dict(zip(eye0_sorted["frames"], eye0_dip))
     eye1_dip_by_frame = dict(zip(eye1_sorted["frames"], eye1_dip))
-    blink_frame_set = {
+    combined_blink_frame_set = {
         f for f in eye0_dip_by_frame.keys() & eye1_dip_by_frame.keys()
         if eye0_dip_by_frame[f] > blink_n_std and eye1_dip_by_frame[f] > blink_n_std
     }
 
-    cleaned_mask = (analysis_df["processing_level"] == "cleaned")
+    cleaned_mask = analysis_df["processing_level"] == "cleaned"
     eye0_analysis = analysis_df[(analysis_df["video"] == "eye0") & cleaned_mask]
     eye1_analysis = analysis_df[(analysis_df["video"] == "eye1") & cleaned_mask]
 
-    blink_countdown = 0
+    eye0_blink_countdown = 0
+    eye1_blink_countdown = 0
+    combined_blink_countdown = 0
 
     for frame in sorted(confidence_df["frames"].unique()):
         frame_mask = confidence_df["frames"] == frame
+        eye0_is_blink = frame in eye0_blink_frames
+        eye1_is_blink = frame in eye1_blink_frames
 
-        if frame in blink_frame_set:
+        if eye0_is_blink:
             confidence_df.loc[frame_mask & eye0_mask, "blink_threshold"] = 0
-            confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
-            blink_countdown = blink_trailing_frames
-            continue
-        elif blink_countdown > 0:
+            eye0_blink_countdown = blink_trailing_frames
+        elif eye0_blink_countdown > 0:
             confidence_df.loc[frame_mask & eye0_mask, "blink_threshold"] = 0
+            eye0_blink_countdown -= 1
+
+        if eye1_is_blink:
             confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
-            blink_countdown -= 1
-            continue
+            eye1_blink_countdown = blink_trailing_frames
+        elif eye1_blink_countdown > 0:
+            confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
+            eye1_blink_countdown -= 1
 
-        confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"] = check_single_eye(frame, vertical_threshold, horizontal_threshold, eye0_analysis)
-        confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"] = check_single_eye(frame, vertical_threshold, horizontal_threshold, eye1_analysis)
+        if frame in combined_blink_frame_set:
+            confidence_df.loc[frame_mask & eye0_mask, "combined_blink_threshold"] = 0
+            confidence_df.loc[frame_mask & eye1_mask, "combined_blink_threshold"] = 0
+            combined_blink_countdown = blink_trailing_frames
+        elif combined_blink_countdown > 0:
+            confidence_df.loc[frame_mask & eye0_mask, "combined_blink_threshold"] = 0
+            confidence_df.loc[frame_mask & eye1_mask, "combined_blink_threshold"] = 0
+            combined_blink_countdown -= 1
 
-    confidence_df["good_data"] = ((confidence_df["blink_threshold"] == 1) & (confidence_df["confidence_threshold"] == 1) & (confidence_df["eye_position_threshold"] == 1)).astype(int)
+        if not eye0_is_blink and eye0_blink_countdown == 0:
+            confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"] = check_single_eye(frame, vertical_threshold, horizontal_threshold, eye0_analysis)
+        if not eye1_is_blink and eye1_blink_countdown == 0:
+            confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"] = check_single_eye(frame, vertical_threshold, horizontal_threshold, eye1_analysis)
 
-    # Density check: mark frames where the surrounding window has too many bad frames.
-    # Done per camera so each eye is evaluated independently.
+    confidence_df["good_data"] = (
+        (confidence_df["blink_threshold"] == 1)
+        & (confidence_df["combined_blink_threshold"] == 1)
+        & (confidence_df["confidence_threshold"] == 1)
+        & (confidence_df["eye_position_threshold"] == 1)
+    ).astype(int)
+
+    # Density check: mark frames where the surrounding window has too many bad frames, per camera
     confidence_df["density_threshold"] = 1
     for camera in confidence_df["camera"].unique():
         camera_mask = confidence_df["camera"] == camera
         camera_df = confidence_df[camera_mask].sort_values("frames")
         bad_fraction = (1 - camera_df["good_data"]).rolling(window=density_window, center=True, min_periods=1).mean()
-        density_ok = (bad_fraction <= max_bad_fraction).astype(int)
-        confidence_df.loc[camera_mask, "density_threshold"] = density_ok.values
+        confidence_df.loc[camera_mask, "density_threshold"] = (bad_fraction <= max_bad_fraction).astype(int).values
 
-    confidence_df["good_data"] = ((confidence_df["blink_threshold"] == 1) & (confidence_df["confidence_threshold"] == 1) & (confidence_df["eye_position_threshold"] == 1) & (confidence_df["density_threshold"] == 1)).astype(int)
+    confidence_df["good_data"] = (
+        (confidence_df["blink_threshold"] == 1)
+        & (confidence_df["combined_blink_threshold"] == 1)
+        & (confidence_df["confidence_threshold"] == 1)
+        & (confidence_df["eye_position_threshold"] == 1)
+        & (confidence_df["density_threshold"] == 1)
+    ).astype(int)
 
     return confidence_df
+
 
 def bad_eye_data(recording_folder: RecordingFolder):
     get_mean_dlc_confidence(recording_folder=recording_folder)
 
     dlc_confidence_csv = recording_folder.eye_data / "eye_model_v3_mean_confidence.csv"
-
     dlc_confidence_df = pd.read_csv(dlc_confidence_csv)
     eye_analysis_df = pd.read_csv(recording_folder.eye_data_csv)
 
     start_time = perf_counter()
     updated_df = find_bad_eye_data(confidence_df=dlc_confidence_df, analysis_df=eye_analysis_df)
     end_time = perf_counter()
+
     updated_df.to_csv(dlc_confidence_csv, index=False)
     print(f"Searching for eye data took {end_time - start_time} s")
     percent_zeros = (updated_df['good_data'] == 0).mean() * 100
     print(f"Percent of bad data found was {percent_zeros:.2f}%")
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     recording_folder = RecordingFolder.from_folder_path(
         Path("/home/scholl-lab/ferret_recordings/session_2025-07-09_ferret_757_EyeCameras_P41_E13/full_recording")
     )

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -42,7 +42,7 @@ def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold
 def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
-        confidence_n_std: float = 3.0,
+        confidence_n_std: float = 4.0,
         blink_baseline_window: int = 500,
         blink_n_std: float = 3.0,
         blink_trailing_frames: int = 10,
@@ -61,7 +61,7 @@ def find_bad_eye_data(
     # Confidence threshold: per-camera, flag frames more than confidence_n_std below session mean
     for camera_mask in [eye0_mask, eye1_mask]:
         conf = confidence_df.loc[camera_mask, "mean_confidence"]
-        threshold = conf.median() - (confidence_n_std * conf.std())
+        threshold = conf[conf >= conf.quantile(0.10)].median() - (confidence_n_std * conf.std())
         confidence_df.loc[camera_mask, "confidence_threshold"] = (conf > threshold).astype(int).values
 
     # Blink detection: both eyes must dip simultaneously below their rolling median baseline.
@@ -136,7 +136,7 @@ def bad_eye_data(recording_folder: RecordingFolder):
 
 if __name__=='__main__':
     recording_folder = RecordingFolder.from_folder_path(
-        Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/clips/0m_37s-1m_37s")
+        Path("/home/scholl-lab/ferret_recordings/session_2025-07-09_ferret_757_EyeCameras_P41_E13/full_recording")
     )
 
     bad_eye_data(recording_folder=recording_folder)

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -255,7 +255,7 @@ def bad_eye_data(recording_folder: RecordingFolder):
 
 if __name__ == '__main__':
     recording_folder = RecordingFolder.from_folder_path(
-        Path("/home/scholl-lab/ferret_recordings/session_2025-07-09_ferret_757_EyeCameras_P41_E13/full_recording")
+        Path("/home/scholl-lab/ferret_recordings/session_2025-10-16_ferret_402_E07/full_recording")
     )
 
     bad_eye_data(recording_folder=recording_folder)

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -6,34 +6,30 @@ from python_code.utilities.folder_utilities.recording_folder import RecordingFol
 from python_code.utilities.get_mean_dlc_confidence import get_mean_dlc_confidence
 
 
-def check_single_eye(frame: int, vertical_threshold: float, horizontal_threshold: float, analysis_df: pd.DataFrame) -> int:
-    filtered_rows = analysis_df[analysis_df["frame"] == frame]
+def _compute_eye_position_threshold(
+    analysis_df: pd.DataFrame,
+    vertical_threshold: float,
+    horizontal_threshold: float,
+) -> pd.Series:
+    """Return a Series indexed by frame with value 1 (good) or 0 (bad).
+    Frames with missing keypoints default to 0."""
+    tear_duct = analysis_df[analysis_df["keypoint"] == "tear_duct"].groupby("frame")["x"].first()
+    outer_eye = analysis_df[analysis_df["keypoint"] == "outer_eye"].groupby("frame")["x"].first()
+    pupils = analysis_df[analysis_df["keypoint"].isin(["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])]
+    pupil_x = pupils.groupby("frame")["x"].mean()
+    pupil_y = pupils.groupby("frame")["y"].mean()
 
-    if len(filtered_rows) == 0:
-        print(f"Warning: no rows remaining after filtering for frame {frame}")
-        return 0
+    valid = tear_duct.index.intersection(outer_eye.index).intersection(pupil_x.index)
+    td, oe, px, py = tear_duct[valid], outer_eye[valid], pupil_x[valid], pupil_y[valid]
 
-    tear_duct_row = filtered_rows[filtered_rows["keypoint"] == 'tear_duct']
-    outer_eye_row = filtered_rows[filtered_rows["keypoint"] == 'outer_eye']
-    pupil_points = filtered_rows[filtered_rows["keypoint"].isin(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'])]
-
-    if tear_duct_row.empty or outer_eye_row.empty or pupil_points.empty:
-        print(f"Warning: missing keypoints for frame {frame}")
-        return 0
-
-    tear_duct_x = tear_duct_row['x'].iloc[0]
-    outer_eye_x = outer_eye_row['x'].iloc[0]
-    pupil_center_x = pupil_points['x'].mean()
-    pupil_center_y = pupil_points['y'].mean()
-
-    if (outer_eye_x - tear_duct_x) < horizontal_threshold:
-        return 0
-    if pupil_center_x < tear_duct_x or pupil_center_x > outer_eye_x:
-        return 0
-    if abs(pupil_center_y) > vertical_threshold:
-        return 0
-
-    return 1
+    ok = (
+        ((oe - td) >= horizontal_threshold)
+        & (px >= td) & (px <= oe)
+        & (py.abs() <= vertical_threshold)
+    )
+    result = pd.Series(0, index=valid)
+    result[valid] = ok.astype(int)
+    return result
 
 
 def _find_blink_frames(eye_sorted: pd.DataFrame, drop_threshold: float, n_recovery: int) -> set:
@@ -53,12 +49,23 @@ def _find_blink_frames(eye_sorted: pd.DataFrame, drop_threshold: float, n_recove
     return bad_frames
 
 
+def _expand_blink_trail(blink_frames: set, sorted_frames: list, trailing: int) -> set:
+    if not blink_frames or trailing == 0:
+        return set(blink_frames)
+    frame_to_idx = {f: i for i, f in enumerate(sorted_frames)}
+    expanded = set(blink_frames)
+    for f in blink_frames:
+        idx = frame_to_idx[f]
+        for j in range(1, trailing + 1):
+            if idx + j < len(sorted_frames):
+                expanded.add(sorted_frames[idx + j])
+    return expanded
+
+
 def find_bad_eye_data(
         confidence_df: pd.DataFrame,
         analysis_df: pd.DataFrame,
-        # Low-level params (loose — fewest frames rejected)
-        confidence_n_std_low: float = 6.0,
-        # Medium-level params (current defaults)
+        # Low/medium-level params (shared confidence threshold)
         confidence_n_std: float = 4.0,
         blink_drop_n_std: float = 1.0,
         blink_n_std: float = 3.0,
@@ -75,7 +82,6 @@ def find_bad_eye_data(
         density_window: int = 150,
         max_bad_fraction: float = 0.4,
     ) -> pd.DataFrame:
-    confidence_df["confidence_threshold_low"] = 1
     confidence_df["confidence_threshold"] = 1
     confidence_df["confidence_threshold_high"] = 1
     confidence_df["blink_threshold"] = 1
@@ -86,12 +92,11 @@ def find_bad_eye_data(
     eye0_mask = confidence_df["camera"] == "eye0"
     eye1_mask = confidence_df["camera"] == "eye1"
 
-    # Confidence thresholds: all three levels computed per-camera in one pass
+    # Confidence thresholds: low/medium share the same threshold, high uses tighter params
     for camera_mask in [eye0_mask, eye1_mask]:
         conf = confidence_df.loc[camera_mask, "mean_confidence"]
         trimmed_median = conf[conf >= conf.quantile(0.10)].median()
         std = conf.std()
-        confidence_df.loc[camera_mask, "confidence_threshold_low"]  = (conf > trimmed_median - confidence_n_std_low  * std).astype(int).values
         confidence_df.loc[camera_mask, "confidence_threshold"]      = (conf > trimmed_median - confidence_n_std      * std).astype(int).values
         confidence_df.loc[camera_mask, "confidence_threshold_high"] = (conf > trimmed_median - confidence_n_std_high * std).astype(int).values
 
@@ -123,79 +128,35 @@ def find_bad_eye_data(
         if eye0_dip_by_frame[f] > blink_n_std_high and eye1_dip_by_frame[f] > blink_n_std_high
     }
 
+    # Expand all blink sets with trailing frames
+    sorted_frames = sorted(confidence_df["frames"].unique())
+    eye0_blink_all          = _expand_blink_trail(eye0_blink_frames,             sorted_frames, blink_trailing_frames)
+    eye1_blink_all          = _expand_blink_trail(eye1_blink_frames,             sorted_frames, blink_trailing_frames)
+    eye0_blink_all_high     = _expand_blink_trail(eye0_blink_frames_high,        sorted_frames, blink_trailing_frames)
+    eye1_blink_all_high     = _expand_blink_trail(eye1_blink_frames_high,        sorted_frames, blink_trailing_frames)
+    combined_blink_all      = _expand_blink_trail(combined_blink_frame_set,      sorted_frames, blink_trailing_frames)
+    combined_blink_all_high = _expand_blink_trail(combined_blink_frame_set_high, sorted_frames, blink_trailing_frames)
+
+    # Blink threshold columns — vectorized assignment
+    confidence_df.loc[confidence_df["frames"].isin(eye0_blink_all) & eye0_mask, "blink_threshold"] = 0
+    confidence_df.loc[confidence_df["frames"].isin(eye1_blink_all) & eye1_mask, "blink_threshold"] = 0
+    confidence_df.loc[confidence_df["frames"].isin(eye0_blink_all_high) & eye0_mask, "blink_threshold_high"] = 0
+    confidence_df.loc[confidence_df["frames"].isin(eye1_blink_all_high) & eye1_mask, "blink_threshold_high"] = 0
+    confidence_df.loc[confidence_df["frames"].isin(combined_blink_all), "combined_blink_threshold"] = 0
+    confidence_df.loc[confidence_df["frames"].isin(combined_blink_all_high), "combined_blink_threshold_high"] = 0
+
+    # Eye position threshold — computed for all frames at once
     cleaned_mask = analysis_df["processing_level"] == "cleaned"
     eye0_analysis = analysis_df[(analysis_df["video"] == "eye0") & cleaned_mask]
     eye1_analysis = analysis_df[(analysis_df["video"] == "eye1") & cleaned_mask]
-
-    eye0_blink_countdown = 0
-    eye1_blink_countdown = 0
-    eye0_blink_countdown_high = 0
-    eye1_blink_countdown_high = 0
-    combined_blink_countdown = 0
-    combined_blink_countdown_high = 0
-
-    for frame in sorted(confidence_df["frames"].unique()):
-        frame_mask = confidence_df["frames"] == frame
-        eye0_is_blink = frame in eye0_blink_frames
-        eye1_is_blink = frame in eye1_blink_frames
-        eye0_is_blink_high = frame in eye0_blink_frames_high
-        eye1_is_blink_high = frame in eye1_blink_frames_high
-
-        # Medium per-eye blink
-        if eye0_is_blink:
-            confidence_df.loc[frame_mask & eye0_mask, "blink_threshold"] = 0
-            eye0_blink_countdown = blink_trailing_frames
-        elif eye0_blink_countdown > 0:
-            confidence_df.loc[frame_mask & eye0_mask, "blink_threshold"] = 0
-            eye0_blink_countdown -= 1
-
-        if eye1_is_blink:
-            confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
-            eye1_blink_countdown = blink_trailing_frames
-        elif eye1_blink_countdown > 0:
-            confidence_df.loc[frame_mask & eye1_mask, "blink_threshold"] = 0
-            eye1_blink_countdown -= 1
-
-        # High per-eye blink
-        if eye0_is_blink_high:
-            confidence_df.loc[frame_mask & eye0_mask, "blink_threshold_high"] = 0
-            eye0_blink_countdown_high = blink_trailing_frames
-        elif eye0_blink_countdown_high > 0:
-            confidence_df.loc[frame_mask & eye0_mask, "blink_threshold_high"] = 0
-            eye0_blink_countdown_high -= 1
-
-        if eye1_is_blink_high:
-            confidence_df.loc[frame_mask & eye1_mask, "blink_threshold_high"] = 0
-            eye1_blink_countdown_high = blink_trailing_frames
-        elif eye1_blink_countdown_high > 0:
-            confidence_df.loc[frame_mask & eye1_mask, "blink_threshold_high"] = 0
-            eye1_blink_countdown_high -= 1
-
-        # Combined medium blink
-        if frame in combined_blink_frame_set:
-            confidence_df.loc[frame_mask & eye0_mask, "combined_blink_threshold"] = 0
-            confidence_df.loc[frame_mask & eye1_mask, "combined_blink_threshold"] = 0
-            combined_blink_countdown = blink_trailing_frames
-        elif combined_blink_countdown > 0:
-            confidence_df.loc[frame_mask & eye0_mask, "combined_blink_threshold"] = 0
-            confidence_df.loc[frame_mask & eye1_mask, "combined_blink_threshold"] = 0
-            combined_blink_countdown -= 1
-
-        # Combined high blink
-        if frame in combined_blink_frame_set_high:
-            confidence_df.loc[frame_mask & eye0_mask, "combined_blink_threshold_high"] = 0
-            confidence_df.loc[frame_mask & eye1_mask, "combined_blink_threshold_high"] = 0
-            combined_blink_countdown_high = blink_trailing_frames
-        elif combined_blink_countdown_high > 0:
-            confidence_df.loc[frame_mask & eye0_mask, "combined_blink_threshold_high"] = 0
-            confidence_df.loc[frame_mask & eye1_mask, "combined_blink_threshold_high"] = 0
-            combined_blink_countdown_high -= 1
-
-        # Eye position — computed once per frame, skipped during medium blink windows
-        if not eye0_is_blink and eye0_blink_countdown == 0:
-            confidence_df.loc[frame_mask & eye0_mask, "eye_position_threshold"] = check_single_eye(frame, vertical_threshold, horizontal_threshold, eye0_analysis)
-        if not eye1_is_blink and eye1_blink_countdown == 0:
-            confidence_df.loc[frame_mask & eye1_mask, "eye_position_threshold"] = check_single_eye(frame, vertical_threshold, horizontal_threshold, eye1_analysis)
+    eye0_pos = _compute_eye_position_threshold(eye0_analysis, vertical_threshold, horizontal_threshold)
+    eye1_pos = _compute_eye_position_threshold(eye1_analysis, vertical_threshold, horizontal_threshold)
+    confidence_df.loc[eye0_mask, "eye_position_threshold"] = (
+        confidence_df.loc[eye0_mask, "frames"].map(eye0_pos).fillna(0).astype(int).values
+    )
+    confidence_df.loc[eye1_mask, "eye_position_threshold"] = (
+        confidence_df.loc[eye1_mask, "frames"].map(eye1_pos).fillna(0).astype(int).values
+    )
 
     # Compute density from the medium-level pre-density good_data
     good_data_medium_pre_density = (
@@ -213,7 +174,7 @@ def find_bad_eye_data(
 
     # Final good_data columns for each level
     confidence_df["good_data_low"] = (
-        (confidence_df["confidence_threshold_low"] == 1)
+        (confidence_df["confidence_threshold"] == 1)
         & (confidence_df["eye_position_threshold"] == 1)
     ).astype(int)
 

--- a/python_code/utilities/find_bad_eye_data.py
+++ b/python_code/utilities/find_bad_eye_data.py
@@ -93,32 +93,47 @@ def find_bad_eye_data(
     eye0_mask = confidence_df["camera"] == "eye0"
     eye1_mask = confidence_df["camera"] == "eye1"
 
-    # Confidence thresholds: low/medium share the same threshold, high uses tighter params
+    # Eye position threshold — computed first so confidence stats exclude position-failing frames
+    cleaned_mask = analysis_df["processing_level"] == "cleaned"
+    eye0_analysis = analysis_df[(analysis_df["video"] == "eye0") & cleaned_mask]
+    eye1_analysis = analysis_df[(analysis_df["video"] == "eye1") & cleaned_mask]
+    eye0_pos = _compute_eye_position_threshold(eye0_analysis, vertical_threshold, horizontal_threshold)
+    eye1_pos = _compute_eye_position_threshold(eye1_analysis, vertical_threshold, horizontal_threshold)
+    confidence_df.loc[eye0_mask, "eye_position_threshold"] = (
+        confidence_df.loc[eye0_mask, "frames"].map(eye0_pos).fillna(0).astype(int).values
+    )
+    confidence_df.loc[eye1_mask, "eye_position_threshold"] = (
+        confidence_df.loc[eye1_mask, "frames"].map(eye1_pos).fillna(0).astype(int).values
+    )
+
+    # Confidence thresholds: statistics computed on position-passing frames only, applied to all
     for camera_mask in [eye0_mask, eye1_mask]:
+        position_passing = camera_mask & (confidence_df["eye_position_threshold"] == 1)
+        conf_for_stats = confidence_df.loc[position_passing, "mean_confidence"]
+        trimmed_median = conf_for_stats[conf_for_stats >= conf_for_stats.quantile(0.10)].median()
+        std = conf_for_stats.std()
         conf = confidence_df.loc[camera_mask, "mean_confidence"]
-        trimmed_median = conf[conf >= conf.quantile(0.10)].median()
-        std = conf.std()
         confidence_df.loc[camera_mask, "confidence_threshold"]      = (conf > trimmed_median - confidence_n_std      * std).astype(int).values
         confidence_df.loc[camera_mask, "confidence_threshold_high"] = (conf > trimmed_median - confidence_n_std_high * std).astype(int).values
 
-    # Per-eye shape-based blink detection at medium and high params
-    eye0_sorted = confidence_df[eye0_mask].sort_values("frames").reset_index(drop=True)
-    eye1_sorted = confidence_df[eye1_mask].sort_values("frames").reset_index(drop=True)
-    eye0_std = eye0_sorted["mean_confidence"].std()
-    eye1_std = eye1_sorted["mean_confidence"].std()
+    # Per-eye shape-based blink detection on position-passing frames only
+    eye0_position_passing = confidence_df[eye0_mask & (confidence_df["eye_position_threshold"] == 1)].sort_values("frames").reset_index(drop=True)
+    eye1_position_passing = confidence_df[eye1_mask & (confidence_df["eye_position_threshold"] == 1)].sort_values("frames").reset_index(drop=True)
+    eye0_std = eye0_position_passing["mean_confidence"].std()
+    eye1_std = eye1_position_passing["mean_confidence"].std()
 
-    eye0_blink_frames = _find_blink_frames(eye0_sorted, blink_drop_n_std * eye0_std, blink_n_recovery_frames)
-    eye1_blink_frames = _find_blink_frames(eye1_sorted, blink_drop_n_std * eye1_std, blink_n_recovery_frames)
-    eye0_blink_frames_high = _find_blink_frames(eye0_sorted, blink_drop_n_std_high * eye0_std, blink_n_recovery_frames)
-    eye1_blink_frames_high = _find_blink_frames(eye1_sorted, blink_drop_n_std_high * eye1_std, blink_n_recovery_frames)
+    eye0_blink_frames = _find_blink_frames(eye0_position_passing, blink_drop_n_std * eye0_std, blink_n_recovery_frames)
+    eye1_blink_frames = _find_blink_frames(eye1_position_passing, blink_drop_n_std * eye1_std, blink_n_recovery_frames)
+    eye0_blink_frames_high = _find_blink_frames(eye0_position_passing, blink_drop_n_std_high * eye0_std, blink_n_recovery_frames)
+    eye1_blink_frames_high = _find_blink_frames(eye1_position_passing, blink_drop_n_std_high * eye1_std, blink_n_recovery_frames)
 
-    # Combined blink detection (both eyes simultaneously) at medium and high params
-    eye0_conf = eye0_sorted["mean_confidence"]
-    eye1_conf = eye1_sorted["mean_confidence"]
+    # Combined blink detection (both eyes simultaneously) on position-passing frames only
+    eye0_conf = eye0_position_passing["mean_confidence"]
+    eye1_conf = eye1_position_passing["mean_confidence"]
     eye0_dip = (eye0_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye0_conf) / eye0_conf.std()
     eye1_dip = (eye1_conf.rolling(blink_baseline_window, center=True, min_periods=1).median() - eye1_conf) / eye1_conf.std()
-    eye0_dip_by_frame = dict(zip(eye0_sorted["frames"], eye0_dip))
-    eye1_dip_by_frame = dict(zip(eye1_sorted["frames"], eye1_dip))
+    eye0_dip_by_frame = dict(zip(eye0_position_passing["frames"], eye0_dip))
+    eye1_dip_by_frame = dict(zip(eye1_position_passing["frames"], eye1_dip))
     shared_frames = eye0_dip_by_frame.keys() & eye1_dip_by_frame.keys()
     combined_blink_frame_set = {
         f for f in shared_frames
@@ -145,19 +160,6 @@ def find_bad_eye_data(
     confidence_df.loc[confidence_df["frames"].isin(eye1_blink_all_high) & eye1_mask, "blink_threshold_high"] = 0
     confidence_df.loc[confidence_df["frames"].isin(combined_blink_all), "combined_blink_threshold"] = 0
     confidence_df.loc[confidence_df["frames"].isin(combined_blink_all_high), "combined_blink_threshold_high"] = 0
-
-    # Eye position threshold — computed for all frames at once
-    cleaned_mask = analysis_df["processing_level"] == "cleaned"
-    eye0_analysis = analysis_df[(analysis_df["video"] == "eye0") & cleaned_mask]
-    eye1_analysis = analysis_df[(analysis_df["video"] == "eye1") & cleaned_mask]
-    eye0_pos = _compute_eye_position_threshold(eye0_analysis, vertical_threshold, horizontal_threshold)
-    eye1_pos = _compute_eye_position_threshold(eye1_analysis, vertical_threshold, horizontal_threshold)
-    confidence_df.loc[eye0_mask, "eye_position_threshold"] = (
-        confidence_df.loc[eye0_mask, "frames"].map(eye0_pos).fillna(0).astype(int).values
-    )
-    confidence_df.loc[eye1_mask, "eye_position_threshold"] = (
-        confidence_df.loc[eye1_mask, "frames"].map(eye1_pos).fillna(0).astype(int).values
-    )
 
     # Compute density from the medium-level pre-density good_data
     good_data_medium_pre_density = (


### PR DESCRIPTION
Redo the eye data filtering. Includes: 
- A new viewer to check data quality
- Stricter checks on locations (make sure tear duct and outer eye are sufficiently far from each other)
- Replace set confidence thresholds with statistical checks
- Add a new blink detection threshold based on confidence differential
- Split checks into three confidence levels to allow tunable detection during processing
- Save out threshold booleans into analyzable_output folder
